### PR TITLE
log full arguments on parse json err

### DIFF
--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -154,7 +154,7 @@ class ToolCallAgent(ReActAgent):
         except json.JSONDecodeError:
             error_msg = f"Error parsing arguments for {name}: Invalid JSON format"
             logger.error(
-                f"📝 Oops! The arguments for '{name}' don't make sense - invalid JSON"
+                f"📝 Oops! The arguments for '{name}' don't make sense - invalid JSON, arguments:{command.function.arguments}"
             )
             return f"Error: {error_msg}"
         except Exception as e:


### PR DESCRIPTION
When calling the python_execute tool, if a JSON parsing error occurs, the current version cannot know the specific cause, so it is more reasonable to output the JSON parameters to the log.