### PR TITLE
Add support to Azure OpenAI models

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,8 @@ class LLMSettings(BaseModel):
     model: str = Field(..., description="Model name")
     base_url: str = Field(..., description="API base URL")
     api_key: str = Field(..., description="API key")
+    api_type: str = Field(..., description="API type")
+    api_version: str = Field(..., description="API version")
     max_tokens: int = Field(4096, description="Maximum number of tokens per request")
     temperature: float = Field(1.0, description="Sampling temperature")
 
@@ -74,6 +76,8 @@ class Config:
             "model": base_llm.get("model"),
             "base_url": base_llm.get("base_url"),
             "api_key": base_llm.get("api_key"),
+            "api_type": base_llm.get("api_type", "openai"),
+            "api_version": base_llm.get("api_version"),
             "max_tokens": base_llm.get("max_tokens", 4096),
             "temperature": base_llm.get("temperature", 1.0),
         }

--- a/app/config.py
+++ b/app/config.py
@@ -77,7 +77,7 @@ class Config:
             "base_url": base_llm.get("base_url"),
             "api_key": base_llm.get("api_key"),
             "api_type": base_llm.get("api_type", "openai"),
-            "api_version": base_llm.get("api_version"),
+            "api_version": base_llm.get("api_version", "2024-10-21"),
             "max_tokens": base_llm.get("max_tokens", 4096),
             "temperature": base_llm.get("temperature", 1.0),
         }

--- a/app/llm.py
+++ b/app/llm.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Literal, Optional, Union
 from openai import (
     APIError,
     AsyncOpenAI,
+    AsyncAzureOpenAI,
     AuthenticationError,
     OpenAIError,
     RateLimitError,
@@ -35,9 +36,20 @@ class LLM:
             self.model = llm_config.model
             self.max_tokens = llm_config.max_tokens
             self.temperature = llm_config.temperature
-            self.client = AsyncOpenAI(
-                api_key=llm_config.api_key, base_url=llm_config.base_url
-            )
+            if llm_config.api_type == "openai":
+                self.client = AsyncOpenAI(
+                    api_key=llm_config.api_key, base_url=llm_config.base_url
+                )
+            elif llm_config.api_type == "azure":
+                self.client = AsyncAzureOpenAI(
+                    azure_endpoint=llm_config.base_url,
+                    azure_deployment=llm_config.model,
+                    api_key=llm_config.api_key,
+                    api_version=llm_config.api_version,
+                )
+            else:
+                raise ValueError(f"api_type = {llm_config.api_type} is not supported!")
+
 
     @staticmethod
     def format_messages(messages: List[Union[dict, Message]]) -> List[dict]:

--- a/app/llm.py
+++ b/app/llm.py
@@ -43,7 +43,6 @@ class LLM:
             elif llm_config.api_type == "azure":
                 self.client = AsyncAzureOpenAI(
                     azure_endpoint=llm_config.base_url,
-                    azure_deployment=llm_config.model,
                     api_key=llm_config.api_key,
                     api_version=llm_config.api_version,
                 )


### PR DESCRIPTION
Add support to [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart?tabs=command-line%2Ckeyless%2Ctypescript-keyless%2Cpython-new&pivots=programming-language-python#create-a-new-python-application). An example configuration is like below:
```
# Global LLM configuration
[llm]
model = "gpt-4o" # deployment name
base_url = "https://....openai.azure.com/"
api_key = "..."
max_tokens = 4096
temperature = 0.7
api_type = "azure"
api_version = "2024-10-21"
```