### PR TITLE
feat: add tool finder to find local files

### DIFF
--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -7,6 +7,7 @@ from app.tool.browser_use_tool import BrowserUseTool
 from app.tool.file_saver import FileSaver
 from app.tool.google_search import GoogleSearch
 from app.tool.python_execute import PythonExecute
+from app.tool.finder import Finder
 
 
 class Manus(ToolCallAgent):
@@ -29,6 +30,6 @@ class Manus(ToolCallAgent):
     # Add general-purpose tools to the tool collection
     available_tools: ToolCollection = Field(
         default_factory=lambda: ToolCollection(
-            PythonExecute(), GoogleSearch(), BrowserUseTool(), FileSaver(), Terminate()
+            PythonExecute(), GoogleSearch(), BrowserUseTool(), FileSaver(), Terminate(), Finder()
         )
     )

--- a/app/tool/finder.py
+++ b/app/tool/finder.py
@@ -1,0 +1,116 @@
+import os
+from typing import List, Dict
+import glob
+from pathlib import Path
+
+from app.tool.base import BaseTool
+
+
+class Finder(BaseTool):
+    # use project root as default path
+    _default_path = str(Path(__file__).parent.parent.parent)
+    
+    name: str = "finder"
+    description: str = """Search for a file in a specified local directory by its name or partial name.
+The tool searches for files whose names contain specific keywords and returns the matching files' paths.
+"""
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "directory_path": {
+                "type": "string",
+                "description": f"(optional) The path of the directory to search files in. Defaults to '{_default_path}'.",
+                "default": _default_path,
+            },
+            "file_name_keywords": {
+                "type": "array",
+                "description": "(required) A list of keywords to search for in the file names.",
+                "items": {"type": "string"},
+            },
+            "file_extensions": {
+                "type": "array",
+                "description": "(optional) A list of file extensions to filter by. If not provided, all files will be searched.",
+                "items": {"type": "string"},
+                "default": [],
+            },
+        },
+        "required": ["file_name_keywords"],
+    }
+
+    async def execute(
+        self, directory_path: str = None, file_name_keywords: List[str] = [], file_extensions: List[str] = []
+    ) -> Dict[str, str]:
+        """
+        Search for files in the specified directory whose name contains specific keywords.
+
+        Args:
+            directory_path (str): The path of the directory to search files in. Defaults to parent of parent directory.
+            file_name_keywords (List[str]): A list of keywords to search for in the file names.
+            file_extensions (List[str], optional): A list of file extensions to filter by. Default is all files.
+
+        Returns:
+            Dict[str, list]: A dictionary with list of found files,
+                           or an error message.
+        """
+        try:
+            # Use the class default path if directory_path is None
+            if directory_path is None:
+                directory_path = self._default_path
+                
+            print(f"Searching in directory: {directory_path}")
+            # Ensure the directory exists
+            if not os.path.exists(directory_path):
+                return {"error": f"Directory '{directory_path}' does not exist."}
+
+            # Prepare file extension pattern
+            ext_pattern = ""
+            if file_extensions:
+                # Convert extensions to proper format (ensuring they start with a dot)
+                formatted_exts = [ext if ext.startswith('.') else f'.{ext}' for ext in file_extensions]
+                # Join extensions with comma for glob pattern
+                ext_pattern = f"*{{{''.join(formatted_exts)}}}"
+            else:
+                ext_pattern = "*"  # Match all files
+                
+            # Get absolute path
+            abs_directory_path = Path(directory_path).resolve()
+            
+            # Convert keywords to lowercase for case-insensitive matching
+            lowercase_keywords = [keyword.lower() for keyword in file_name_keywords]
+            
+            # List to store matching files
+            matching_files = []
+            
+            # Use glob to recursively find all files
+            for file_path in glob.glob(f"{abs_directory_path}/**/{ext_pattern}", recursive=True):
+                file_name = Path(file_path).name
+                lowercase_filename = file_name.lower()
+                
+                # Check if file name contains any of the keywords (case-insensitive)
+                if any(keyword in lowercase_filename for keyword in lowercase_keywords):
+                    # Get file size
+                    file_size_bytes = os.path.getsize(file_path)
+                    file_size = self._format_file_size(file_size_bytes)
+                    
+                    # Add file information to the list
+                    matching_files.append({
+                        "file_name": file_name,
+                        "file_path": str(file_path),
+                        "file_size": file_size
+                    })
+            
+            if matching_files:
+                return {"files_found": matching_files}
+            else:
+                return {"message": "No matching files found."}
+                
+        except Exception as e:
+            return {"error": f"Error searching files: {str(e)}"}
+            
+    def _format_file_size(self, size_bytes: int) -> str:
+        """Format file size in a human-readable format"""
+        for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+            if size_bytes < 1024.0 or unit == 'TB':
+                break
+            size_bytes /= 1024.0
+        return f"{size_bytes:.2f} {unit}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ aiofiles~=24.1.0
 pydantic_core~=2.27.2
 colorama~=0.4.6
 playwright~=1.49.1
+
+glob
+pathlib


### PR DESCRIPTION
# Finder

This Python module defines a tool called "Finder" that searches for files within a specified directory based on their names. Its name "Finder" comes from MacOS.

## Key Functionality:
- Searches recursively through directories to find files that contain specified keywords in their filenames
- Allows filtering by file extensions (optional)
- Returns file metadata including paths, names, and sizes
- Does not return file contents, only metadata
- Uses case-insensitive matching for filename keywords

## Use Case:
- Prompt
Find local file readme, then turn it into ppt with python
- Result
[README.pptx](https://github.com/user-attachments/files/19128994/README.pptx)
