### PR TITLE
feat(browser_use_tool): add 'get_text' action to browser use tool

### DIFF
--- a/app/tool/browser_use_tool.py
+++ b/app/tool/browser_use_tool.py
@@ -11,6 +11,7 @@ from pydantic_core.core_schema import ValidationInfo
 
 from app.tool.base import BaseTool, ToolResult
 
+
 _BROWSER_DESCRIPTION = """
 Interact with a web browser to perform various actions such as navigation, element interaction,
 content extraction, and tab management. Supported actions include:
@@ -173,23 +174,23 @@ class BrowserUseTool(BaseTool):
                 elif action == "screenshot":
                     screenshot = await context.take_screenshot(full_page=True)
                     return ToolResult(
-                        output=
-                        f"Screenshot captured (base64 length: {len(screenshot)})",
+                        output=f"Screenshot captured (base64 length: {len(screenshot)})",
                         system=screenshot,
                     )
 
                 elif action == "get_html":
                     html = await context.get_page_html()
-                    truncated = html[:2000] + "..." if len(
-                        html) > 2000 else html
+                    truncated = html[:2000] + "..." if len(html) > 2000 else html
                     return ToolResult(output=truncated)
 
                 elif action == "get_text":
-                    text = await context.execute_javascript('document.body.innerText')
+                    text = await context.execute_javascript("document.body.innerText")
                     return ToolResult(output=text)
 
                 elif action == "read_links":
-                    links = await context.execute_javascript("document.querySelectorAll('a[href]').forEach((elem) => {if (elem.innerText) {console.log(elem.innerText, elem.href)}})")
+                    links = await context.execute_javascript(
+                        "document.querySelectorAll('a[href]').forEach((elem) => {if (elem.innerText) {console.log(elem.innerText, elem.href)}})"
+                    )
                     return ToolResult(output=links)
 
                 elif action == "execute_js":

--- a/app/tool/browser_use_tool.py
+++ b/app/tool/browser_use_tool.py
@@ -20,6 +20,7 @@ content extraction, and tab management. Supported actions include:
 - 'screenshot': Capture a screenshot
 - 'get_html': Get page HTML content
 - 'get_text': Get text content of the page
+- 'read_links': Get all links on the page
 - 'execute_js': Execute JavaScript code
 - 'scroll': Scroll the page
 - 'switch_tab': Switch to a specific tab
@@ -186,6 +187,10 @@ class BrowserUseTool(BaseTool):
                 elif action == "get_text":
                     text = await context.execute_javascript('document.body.innerText')
                     return ToolResult(output=text)
+
+                elif action == "read_links":
+                    links = await context.execute_javascript("document.querySelectorAll('a[href]').forEach((elem) => {if (elem.innerText) {console.log(elem.innerText, elem.href)}})")
+                    return ToolResult(output=links)
 
                 elif action == "execute_js":
                     if not script:

--- a/app/tool/browser_use_tool.py
+++ b/app/tool/browser_use_tool.py
@@ -11,7 +11,6 @@ from pydantic_core.core_schema import ValidationInfo
 
 from app.tool.base import BaseTool, ToolResult
 
-
 _BROWSER_DESCRIPTION = """
 Interact with a web browser to perform various actions such as navigation, element interaction,
 content extraction, and tab management. Supported actions include:
@@ -20,6 +19,7 @@ content extraction, and tab management. Supported actions include:
 - 'input_text': Input text into an element
 - 'screenshot': Capture a screenshot
 - 'get_html': Get page HTML content
+- 'get_text': Get text content of the page
 - 'execute_js': Execute JavaScript code
 - 'scroll': Scroll the page
 - 'switch_tab': Switch to a specific tab
@@ -43,6 +43,7 @@ class BrowserUseTool(BaseTool):
                     "input_text",
                     "screenshot",
                     "get_html",
+                    "get_text",
                     "execute_js",
                     "scroll",
                     "switch_tab",
@@ -171,14 +172,20 @@ class BrowserUseTool(BaseTool):
                 elif action == "screenshot":
                     screenshot = await context.take_screenshot(full_page=True)
                     return ToolResult(
-                        output=f"Screenshot captured (base64 length: {len(screenshot)})",
+                        output=
+                        f"Screenshot captured (base64 length: {len(screenshot)})",
                         system=screenshot,
                     )
 
                 elif action == "get_html":
                     html = await context.get_page_html()
-                    truncated = html[:2000] + "..." if len(html) > 2000 else html
+                    truncated = html[:2000] + "..." if len(
+                        html) > 2000 else html
                     return ToolResult(output=truncated)
+
+                elif action == "get_text":
+                    text = await context.execute_javascript('document.body.innerText')
+                    return ToolResult(output=text)
 
                 elif action == "execute_js":
                     if not script:


### PR DESCRIPTION
**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Allow LLM to read the text content from the page, via JavaScript `document.body.innerText`

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->
Nope

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->
LLM becomes more available and more reliable when extracting content from a specific webpage.

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->
In my test case, I asked `When is Zhejiang University` founded, and Manus (with an LLM core of gpt-4o) did Google search, open the Wikipedia page of ZJU, and read the text content of the page.

**Other**
<!-- Additional notes about this PR. -->
