### PR TITLE
Support extract clean text from html rather than raw html

### DIFF
--- a/app/tool/browser_use_tool.py
+++ b/app/tool/browser_use_tool.py
@@ -9,8 +9,7 @@ from browser_use.dom.service import DomService
 from pydantic import Field, field_validator
 from pydantic_core.core_schema import ValidationInfo
 from pyquery import PyQuery as pq
-from loguru import logger
-
+from app.logger import logger
 from app.tool.base import BaseTool, ToolResult
 
 

--- a/app/tool/browser_use_tool.py
+++ b/app/tool/browser_use_tool.py
@@ -21,6 +21,7 @@ content extraction, and tab management. Supported actions include:
 - 'input_text': Input text into an element
 - 'screenshot': Capture a screenshot
 - 'get_html': Get page HTML content
+- 'get_text': Get page text content
 - 'execute_js': Execute JavaScript code
 - 'scroll': Scroll the page
 - 'switch_tab': Switch to a specific tab
@@ -44,6 +45,7 @@ class BrowserUseTool(BaseTool):
                     "input_text",
                     "screenshot",
                     "get_html",
+                    "get_text",
                     "execute_js",
                     "scroll",
                     "switch_tab",
@@ -186,9 +188,15 @@ class BrowserUseTool(BaseTool):
 
                 elif action == "get_html":
                     html = await context.get_page_html()
+                    truncated = html[:2000] + \
+                        "..." if len(html) > 2000 else html
+                    return ToolResult(output=truncated)
+
+                elif action == "get_text":
+                    html = await context.get_page_html()
                     extracted_text = self.extract_page_text(html)
                     truncated = extracted_text[:2000] + \
-                        "..." if len(extracted_text) > 2000 else html
+                        "..." if len(extracted_text) > 2000 else extracted_text
                     return ToolResult(output=truncated)
 
                 elif action == "execute_js":

--- a/app/tool/browser_use_tool.py
+++ b/app/tool/browser_use_tool.py
@@ -111,9 +111,9 @@ class BrowserUseTool(BaseTool):
         doc = pq(html)
         doc.remove(
             "script, style, meta, link, noscript, iframe, svg, canvas, audio, video, map, object, embed, applet")
-        clean_text = doc.text()
-        logger.debug(f"Extracted text: {clean_text}")
-        return clean_text
+        extracted_text = doc.text()
+        logger.debug(f"Extracted text: {extracted_text}")
+        return extracted_text
 
     async def execute(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,4 @@ aiofiles~=24.1.0
 pydantic_core~=2.27.2
 colorama~=0.4.6
 playwright~=1.49.1
-
 pyquery~=2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ aiofiles~=24.1.0
 pydantic_core~=2.27.2
 colorama~=0.4.6
 playwright~=1.49.1
+
+pyquery~=2.0.1


### PR DESCRIPTION
## Features
Support a new feature for tool `BrowserUseTool` - extract clean text from html rather than raw html - `get_text`

## Influence

The previous implementation only extract 2000 words of html, which may contains many noise info, like script, style, which will not contain any useful information.

This PR target to solve this issue.

## Result

Example prompt to Manus: you open browser to view baidu.com, then search NBA, and summarize the content, then write the content as file

Before this PR - the extracted content of `get_html`, full of noise content:

<img width="1487" alt="Code 2025-03-09 01 48 41" src="https://github.com/user-attachments/assets/a4b7a0b2-01cf-493e-bcfb-997fbe775121" />

After this PR - the extracted content of `get_text` - contains many useful info:

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/0402f4bd-2105-4f62-9868-3f311dcf4858" />


<img width="1421" alt="Code 2025-03-09 01 47 08" src="https://github.com/user-attachments/assets/2ce25902-cae3-40cd-85f1-c71a776f2b34" />

