### PR TITLE
Add SearxNG support to enhance search engine flexibility

### DIFF
--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -5,7 +5,7 @@ from app.prompt.manus import NEXT_STEP_PROMPT, SYSTEM_PROMPT
 from app.tool import Terminate, ToolCollection
 from app.tool.browser_use_tool import BrowserUseTool
 from app.tool.file_saver import FileSaver
-from app.tool.google_search import GoogleSearch
+from app.tool.search_tool import SearchTool
 from app.tool.python_execute import PythonExecute
 
 
@@ -29,6 +29,6 @@ class Manus(ToolCallAgent):
     # Add general-purpose tools to the tool collection
     available_tools: ToolCollection = Field(
         default_factory=lambda: ToolCollection(
-            PythonExecute(), GoogleSearch(), BrowserUseTool(), FileSaver(), Terminate()
+            PythonExecute(), SearchTool(), BrowserUseTool(), FileSaver(), Terminate()
         )
     )

--- a/app/tool/search/base_search.py
+++ b/app/tool/search/base_search.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+class BaseSearch(ABC):
+    """Abstract base class for search engines"""
+    
+    @abstractmethod
+    async def search(self, query: str, num_results: int = 10) -> List[str]:
+        """
+        Perform search and return list of result URLs
+        
+        Args:
+            query (str): Search query
+            num_results (int): Number of results to return
+            
+        Returns:
+            List[str]: List of search result URLs
+        """
+        pass 

--- a/app/tool/search/google_search.py
+++ b/app/tool/search/google_search.py
@@ -1,0 +1,13 @@
+import asyncio
+from googlesearch import search
+from app.tool.search.base_search import BaseSearch
+
+class GoogleSearch(BaseSearch):
+    """Google search implementation"""
+    
+    async def search(self, query: str, num_results: int = 10) -> list[str]:
+        loop = asyncio.get_event_loop()
+        links = await loop.run_in_executor(
+            None, lambda: list(search(query, num_results=num_results))
+        )
+        return links 

--- a/app/tool/search/search_factory.py
+++ b/app/tool/search/search_factory.py
@@ -1,0 +1,31 @@
+from typing import Dict, Type
+from app.tool.search.base_search import BaseSearch
+from app.tool.search.google_search import GoogleSearch
+from app.tool.search.searxng_search import SearxNGSearch
+
+class SearchFactory:
+    """Search Engine Factory Class"""
+    
+    _engines: Dict[str, Type[BaseSearch]] = {
+        "google": GoogleSearch,
+        "searxng": SearxNGSearch
+    }
+    
+    @classmethod
+    def create_search_engine(cls, engine_type: str) -> BaseSearch:
+        """
+        Create search engine instance
+        
+        Args:
+            engine_type (str): Search engine type
+            
+        Returns:
+            BaseSearch: Search engine instance
+        """
+        if engine_type not in cls._engines:
+            raise ValueError(f"Unsupported search engine type: {engine_type}")
+            
+        engine_class = cls._engines[engine_type]
+        if engine_type == "searxng":
+            return engine_class()  # 可以从配置中读取base_url
+        return engine_class() 

--- a/app/tool/search/searxng_search.py
+++ b/app/tool/search/searxng_search.py
@@ -1,0 +1,49 @@
+import asyncio
+import aiohttp
+from urllib.parse import quote
+from typing import List
+import json
+import logging
+from app.tool.search.base_search import BaseSearch
+
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class SearxNGSearch(BaseSearch):
+    """SearxNG search engine implementation"""
+    
+    def __init__(self, base_url: str = "http://127.0.0.1:8080"):
+        self.base_url = base_url.rstrip('/')
+        
+    async def search(self, query: str, num_results: int = 10) -> List[str]:
+        """
+        Perform search via SearxNG API and return list of URLs
+        
+        Args:
+            query (str): Search query
+            num_results (int): Number of results to return
+            
+        Returns:
+            List[str]: List of search result URLs
+        """
+        encoded_query = quote(query)
+        url = f"{self.base_url}/search?q={encoded_query}&format=json"
+        logger.debug(f"Request URL: {url}")
+        
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    logger.debug(f"Received raw data: {json.dumps(data, ensure_ascii=False, indent=2)}")
+                    
+                    results = [
+                        result['url']
+                        for result in data.get('results', [])[:num_results]
+                        if 'url' in result
+                    ]
+                    logger.debug(f"Processed URL list: {results}")
+                    return results
+                else:
+                    logger.error(f"Request failed with status code: {response.status}")
+                    raise Exception(f"Search request failed: {response.status}")

--- a/app/tool/search/searxng_search.py
+++ b/app/tool/search/searxng_search.py
@@ -35,7 +35,7 @@ class SearxNGSearch(BaseSearch):
             async with session.get(url) as response:
                 if response.status == 200:
                     data = await response.json()
-                    logger.debug(f"Received raw data: {json.dumps(data, ensure_ascii=False, indent=2)}")
+                    # logger.debug(f"Received raw data: {json.dumps(data, ensure_ascii=False, indent=2)}")
                     
                     results = [
                         result['url']

--- a/app/tool/search_tool.py
+++ b/app/tool/search_tool.py
@@ -1,0 +1,62 @@
+from typing import List, Dict, Any
+import tomli
+from pathlib import Path
+from pydantic import Field
+
+from app.tool.base import BaseTool
+from app.tool.search.search_factory import SearchFactory
+from app.tool.search.searxng_search import SearxNGSearch
+
+class SearchTool(BaseTool):
+    name: str = "search"
+    description: str = """Get information by performing web searches and return a list of relevant links.
+"""
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string", 
+                "description": "(required) The search query content",
+            },
+            "num_results": {
+                "type": "integer",
+                "description": "(optional) Number of results to return, defaults to 10",
+                "default": 10,
+            },
+        },
+        "required": ["query"],
+    }
+
+    config: Dict[str, Any] = Field(default_factory=dict)
+    search_engine: Any = Field(default=None)
+
+    def __init__(self):
+        super().__init__()
+        self.config = self._load_config()
+        search_config = self.config.get("search_engine", {})
+        self.search_engine = SearchFactory.create_search_engine(
+            search_config.get("type", "google")
+        )
+        if isinstance(self.search_engine, SearxNGSearch):
+            self.search_engine.base_url = search_config.get("base_url", "http://127.0.0.1:8080")
+
+    def _load_config(self) -> dict:
+        config_path = Path("config/config.toml")
+        if not config_path.exists():
+            return {"search_engine": {"type": "google"}}
+        
+        with open(config_path, "rb") as f:
+            return tomli.load(f)
+
+    async def execute(self, query: str, num_results: int = 10) -> List[str]:
+        """
+        Execute search and return results
+        
+        Args:
+            query (str): Search query
+            num_results (int): Number of results to return
+            
+        Returns:
+            List[str]: List of search result URLs
+        """
+        return await self.search_engine.search(query, num_results) 

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1,8 +1,8 @@
 # Global LLM configuration
 [llm]
-model = "claude-3-5-sonnet"
-base_url = "https://api.openai.com/v1"
-api_key = "sk-..."
+model = "Qwen/Qwen2.5-72B-Instruct-128K"
+base_url = "https://api.siliconflow.cn/v1"
+api_key = "sk-dbmrniiwbmebhgggcerwdlwunyurxhkndjzmuuqtvzbndata"
 max_tokens = 4096
 temperature = 0.0
 
@@ -17,6 +17,11 @@ temperature = 0.0
 
 # Optional configuration for specific LLM models
 [llm.vision]
-model = "claude-3-5-sonnet"
-base_url = "https://api.openai.com/v1"
-api_key = "sk-..."
+model = "Pro/deepseek-ai/DeepSeek-R1"
+base_url = "https://api.siliconflow.cn/v1"
+api_key = "sk-dbmrniiwbmebhgggcerwdlwunyurxhkndjzmuuqtvzbndata"
+
+# Search engine configuration
+[search_engine]
+type = "searxng"  # Supported search engine types: google, searxng
+base_url = "http://127.0.0.1:8080"  # SearxNG service address

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ aiofiles~=24.1.0
 pydantic_core~=2.27.2
 colorama~=0.4.6
 playwright~=1.49.1
+
+tomli~=2.2.1
+aiohttp~=3.8.5


### PR DESCRIPTION
## Add SearxNG support to enhance search engine flexibility

**Features**

- Added SearxNG as an alternative search engine option
- Implemented configurable search engine selection in config.toml
- Maintained compatibility with existing Google search functionality
- Added support for custom SearxNG instance configuration
- Preserved the same interface for all search engines

**Feature Docs**

Configuration example in config.toml:
```toml
[search_engine]
type = "searxng"  # Supported types: google, searxng
base_url = "http://127.0.0.1:8080"  # SearxNG service address
```

Users can easily switch between search engines by modifying the config file:
1. Use Google search (default): `type = "google"`
2. Use SearxNG: `type = "searxng"` with custom `base_url`
3. Extensible design for adding more search engines in future

**Influence**

- Functionality:
  - Free and open-source alternative to Google search
  - More search options for different scenarios
  - Easy to switch between search engines
- Extensibility:
  - Modular design for adding new search engines
  - Configuration-based engine selection
  - No code changes needed to switch engines

**Result**

Example usage remains the same while supporting multiple engines:
```python
# Returns same format regardless of engine choice
results = await search_tool.execute(query="test", num_results=10)
# Returns: ["url1", "url2", ...]
```

**Other**

- Zero breaking changes to existing functionality
- Added documentation for SearxNG configuration
- Prepared foundation for future search engine integrations
- All search engines follow the same interface pattern

<img width="983" alt="searxng" src="https://github.com/user-attachments/assets/e7523008-9dd9-4f85-a100-fe2079709e8a" />
