### PR TITLE
support more search agent ,add baidu search agent

### DIFF
--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -6,8 +6,16 @@ from app.tool import Terminate, ToolCollection
 from app.tool.browser_use_tool import BrowserUseTool
 from app.tool.file_saver import FileSaver
 from app.tool.google_search import GoogleSearch
+from app.tool.baidu_search import BaiduSearch
 from app.tool.python_execute import PythonExecute
+from app.config import config
 
+def get_search_agent():
+    search_agent_config = config.llm["default"].search_agent_config
+    search_agent = GoogleSearch()
+    if search_agent_config == "baidu":
+        search_agent = BaiduSearch()
+    return search_agent
 
 class Manus(ToolCallAgent):
     """
@@ -26,9 +34,12 @@ class Manus(ToolCallAgent):
     system_prompt: str = SYSTEM_PROMPT
     next_step_prompt: str = NEXT_STEP_PROMPT
 
+
     # Add general-purpose tools to the tool collection
     available_tools: ToolCollection = Field(
         default_factory=lambda: ToolCollection(
-            PythonExecute(), GoogleSearch(), BrowserUseTool(), FileSaver(), Terminate()
+            PythonExecute(), get_search_agent(), BrowserUseTool(), FileSaver(), Terminate()
         )
     )
+
+

--- a/app/config.py
+++ b/app/config.py
@@ -23,6 +23,7 @@ class LLMSettings(BaseModel):
     temperature: float = Field(1.0, description="Sampling temperature")
     api_type: str = Field(..., description="AzureOpenai or Openai")
     api_version: str = Field(..., description="Azure Openai version if AzureOpenai")
+    search_agent_config: str = Field(..., description="Search agent used search url")
 
 
 class AppConfig(BaseModel):
@@ -80,6 +81,7 @@ class Config:
             "temperature": base_llm.get("temperature", 1.0),
             "api_type": base_llm.get("api_type", ""),
             "api_version": base_llm.get("api_version", ""),
+            "search_agent_config": base_llm.get("search_agent_config", "google"),
         }
 
         config_dict = {
@@ -97,6 +99,4 @@ class Config:
     @property
     def llm(self) -> Dict[str, LLMSettings]:
         return self._config.llm
-
-
 config = Config()

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -5,7 +5,7 @@ base_url = "https://api.openai.com/v1"
 api_key = "sk-..."
 max_tokens = 4096
 temperature = 0.0
-
+search_agent_config = "baidu"
 # [llm] #AZURE OPENAI:
 # api_type= 'azure'
 # model = "YOUR_MODEL_NAME" #"gpt-4o-mini"


### PR DESCRIPTION
功能
1、实现了支持配置文件配置要使用的引擎搜索
2、支持百度搜索引擎来搜索，不需要开vpn，也可以使用openManus

1、Implemented support for configuring search engines via configuration files.
2、Supports searching with Baidu search engine, no need to enable VPN, and openManus can also be used.


解决了这个诉求：
[https://github.com/mannaandpoem/OpenManus/issues/362](https://github.com/mannaandpoem/OpenManus/pull/url)