### PR TITLE
refactor(config): Adjusting error handling

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -51,51 +51,68 @@ class Config:
 
     @staticmethod
     def _get_config_path() -> Path:
-        root = PROJECT_ROOT
-        config_path = root / "config" / "config.toml"
-        if config_path.exists():
-            return config_path
-        example_path = root / "config" / "config.example.toml"
-        if example_path.exists():
-            return example_path
-        raise FileNotFoundError("No configuration file found in config directory")
+        """Find and return the path to a valid configuration file."""
+        config_locations = [
+            PROJECT_ROOT / "config" / "config.toml",
+            PROJECT_ROOT / "config" / "config.example.toml"
+        ]
+        
+        for location in config_locations:
+            if location.exists():
+                return location
+        
+        locations_str = "\n".join(f"- {loc}" for loc in config_locations)
+        raise FileNotFoundError(
+            f"No configuration file found. Please create a config.toml file in one of these locations:\n{locations_str}"
+        )
 
     def _load_config(self) -> dict:
-        config_path = self._get_config_path()
-        with config_path.open("rb") as f:
-            return tomllib.load(f)
+        try:
+            config_path = self._get_config_path()
+            with config_path.open("rb") as f:
+                return tomllib.load(f)
+        except tomllib.TOMLDecodeError as e:
+            raise ValueError(f"Error parsing configuration file: {e}")
+        except Exception as e:
+            raise RuntimeError(f"Failed to load configuration: {e}")
 
     def _load_initial_config(self):
-        raw_config = self._load_config()
-        base_llm = raw_config.get("llm", {})
-        llm_overrides = {
-            k: v for k, v in raw_config.get("llm", {}).items() if isinstance(v, dict)
-        }
-
-        default_settings = {
-            "model": base_llm.get("model"),
-            "base_url": base_llm.get("base_url"),
-            "api_key": base_llm.get("api_key"),
-            "max_tokens": base_llm.get("max_tokens", 4096),
-            "temperature": base_llm.get("temperature", 1.0),
-            "api_type": base_llm.get("api_type", ""),
-            "api_version": base_llm.get("api_version", ""),
-        }
-
-        config_dict = {
-            "llm": {
-                "default": default_settings,
-                **{
-                    name: {**default_settings, **override_config}
-                    for name, override_config in llm_overrides.items()
-                },
+        try:
+            raw_config = self._load_config()
+            base_llm = raw_config.get("llm", {})
+                
+            llm_overrides = {
+                k: v for k, v in base_llm.items() if isinstance(v, dict)
             }
-        }
 
-        self._config = AppConfig(**config_dict)
+            default_settings = {
+                "model": base_llm.get("model"),
+                "base_url": base_llm.get("base_url"),
+                "api_key": base_llm.get("api_key"),
+                "max_tokens": base_llm.get("max_tokens", 4096),
+                "temperature": base_llm.get("temperature", 1.0),
+                "api_type": base_llm.get("api_type", ""),
+                "api_version": base_llm.get("api_version", ""),
+            }
+
+            config_dict = {
+                "llm": {
+                    "default": default_settings,
+                    **{
+                        name: {**default_settings, **override_config}
+                        for name, override_config in llm_overrides.items()
+                    },
+                }
+            }
+
+            self._config = AppConfig(**config_dict)
+        except Exception as e:
+            raise RuntimeError(f"Failed to initialize configuration: {e}")
 
     @property
     def llm(self) -> Dict[str, LLMSettings]:
+        if not self._config:
+            raise RuntimeError("Configuration not initialized")
         return self._config.llm
 
 


### PR DESCRIPTION
**Features**
Improve error handling when loading config

**Feature Docs**


**Influence**
In `_load_initial_config` we are using base_llm.items() directly instead of fetching again from raw_config 

**Result**
```
2025-03-10 08:03:52.122 | WARNING  | __main__:main:19 - Processing your request...
2025-03-10 08:03:52.123 | INFO     | app.agent.base:run:137 - Executing step 1/30
2025-03-10 08:03:54.456 | INFO     | app.agent.toolcall:think:53 - ✨ Manus's thoughts: None
2025-03-10 08:03:54.456 | INFO     | app.agent.toolcall:think:54 - 🛠️ Manus selected 1 tools to use
2025-03-10 08:03:54.457 | INFO     | app.agent.toolcall:think:58 - 🧰 Tools being prepared: ['google_search']
2025-03-10 08:03:54.459 | INFO     | app.agent.toolcall:execute_tool:140 - 🔧 Activating tool: 'google_search'...
2025-03-10 08:03:55.318 | ERROR    | app.agent.toolcall:execute_tool:162 - ⚠️ Tool 'google_search' encountered a problem: 429 Client Error: Too Many Requests for url: https://www.google.com/sorry/index?continue=https://www.google.com/search%3Fq%3DBTLG11%2Bstock%2Bprice%26num%3D12%26hl%3Den%26start%3D0%26safe%3Dactive&hl=en&q=EhAoBAFMdaqEslUsV9jMtaYJGJqOu74GIjCPc9pJFH_P8Xjm0aPLB7sd9uuHT5WyONiEp0GWRRO37UfNlTMxemcTrBmFDVaPDPEyAXJaAUM
2025-03-10 08:03:55.318 | INFO     | app.agent.toolcall:act:113 - 🎯 Tool 'google_search' completed its mission! Result: Error: ⚠️ Tool 'google_search' encountered a problem: 429 Client Error: Too Many Requests for url: https://www.google.com/sorry/index?continue=https://www.google.com/search%3Fq%3DBTLG11%2Bstock%2Bprice%26num%3D12%26hl%3Den%26start%3D0%26safe%3Dactive&hl=en&q=EhAoBAFMdaqEslUsV9jMtaYJGJqOu74GIjCPc9pJFH_P8Xjm0aPLB7sd9uuHT5WyONiEp0GWRRO37UfNlTMxemcTrBmFDVaPDPEyAXJaAUM
2025-03-10 08:03:55.319 | INFO     | app.agent.base:run:137 - Executing step 2/30
2025-03-10 08:03:56.590 | INFO     | app.agent.toolcall:think:53 - ✨ Manus's thoughts: None
2025-03-10 08:03:56.591 | INFO     | app.agent.toolcall:think:54 - 🛠️ Manus selected 1 tools to use
2025-03-10 08:03:56.591 | INFO     | app.agent.toolcall:think:58 - 🧰 Tools being prepared: ['browser_use']
2025-03-10 08:03:56.592 | INFO     | app.agent.toolcall:execute_tool:140 - 🔧 Activating tool: 'browser_use'...
```

**Other**
<!-- Additional notes about this PR. -->
