### PR TITLE
add fastapi library to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ aiofiles~=24.1.0
 pydantic_core~=2.27.2
 colorama~=0.4.6
 playwright~=1.49.1
+fastapi==0.115.11


### PR DESCRIPTION
在ubuntu24.04运行python app.py时会报错缺乏fastapi依赖，添加后正常运行。