### PR TITLE
update python_execute

### DIFF
--- a/app/tool/python_execute.py
+++ b/app/tool/python_execute.py
@@ -47,7 +47,7 @@ class PythonExecute(BaseTool):
                 output_buffer = StringIO()
                 sys.stdout = output_buffer
 
-                exec(code, safe_globals, {})
+                exec(code, safe_globals, safe_globals)
 
                 sys.stdout = sys.__stdout__
 


### PR DESCRIPTION
**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- fix python execute code error：when run exec(code, safe_globals, {}), can not find import module error will appeared
for example
`
import datetime

`
here， just set locals=safe_globals, will run successful
