### PR TITLE
fix python_execute __builtins__

### DIFF
--- a/app/tool/python_execute.py
+++ b/app/tool/python_execute.py
@@ -39,7 +39,7 @@ class PythonExecute(BaseTool):
 
         def run_code():
             try:
-                safe_globals = {"__builtins__": dict(__builtins__)}
+                safe_globals = {"__builtins__": {name: getattr(__builtins__, name) for name in dir(__builtins__)}}
 
                 import sys
                 from io import StringIO


### PR DESCRIPTION
Features

fix python execute code error：TypeError: 'module' object is not iterable

safe_globals = {"__builtins__": dict(__builtins__)} . not a dictionary or iterable object, and therefore cannot be passed directly to the dict() function.