### PR TITLE
feat: add support to dump result files inside `output` directory, create if it doesn't exist

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ def get_project_root() -> Path:
 
 PROJECT_ROOT = get_project_root()
 WORKSPACE_ROOT = PROJECT_ROOT / "workspace"
+OUTPUT_DIR = "output"
 
 
 class LLMSettings(BaseModel):

--- a/app/tool/file_saver.py
+++ b/app/tool/file_saver.py
@@ -47,6 +47,10 @@ The tool accepts content and a file path, and saves the content to that location
         try:
             # Ensure the directory exists
             directory = os.path.dirname(file_path)
+            if not directory:
+                directory = "output"
+                file_path = os.path.join(directory, file_path)
+
             if directory and not os.path.exists(directory):
                 os.makedirs(directory)
 

--- a/app/tool/file_saver.py
+++ b/app/tool/file_saver.py
@@ -3,6 +3,7 @@ import os
 import aiofiles
 
 from app.tool.base import BaseTool
+from app.config import PROJECT_ROOT, OUTPUT_DIR
 
 
 class FileSaver(BaseTool):
@@ -48,7 +49,7 @@ The tool accepts content and a file path, and saves the content to that location
             # Ensure the directory exists
             directory = os.path.dirname(file_path)
             if not directory:
-                directory = "output"
+                directory = f"{PROJECT_ROOT}/{OUTPUT_DIR}"
                 file_path = os.path.join(directory, file_path)
 
             if directory and not os.path.exists(directory):


### PR DESCRIPTION
**Features**
To enable the option to store output files inside output/ directory, instead of storing all the generated results files inside root. This helps in de-cluttering the space from root folder.

<hr>

**Feature Docs**
Closes: [Issue 449: ](https://github.com/mannaandpoem/OpenManus/issues/449)


<hr>

**Result**
Before: 
![image](https://github.com/user-attachments/assets/39304729-0036-49ef-9a41-1e140aed40e3)


After:
![image](https://github.com/user-attachments/assets/ba39de09-f595-4579-a279-274340ecfda3)

<hr>

**Other**
Tested the changes, with multiple configurations:
- no output directory existing
- with output directory existing
- no output files (with our without directory)
