### PR TITLE
Fix type conversion error for `num_results` parameter in `google_search` tool

### DIFF
--- a/app/tool/google_search.py
+++ b/app/tool/google_search.py
@@ -39,6 +39,13 @@ The tool returns a list of URLs that match the search query.
         Returns:
             List[str]: A list of URLs matching the search query.
         """
+        # Ensure num_results is an integer
+        if isinstance(num_results, str):
+            try:
+                num_results = int(num_results)
+            except ValueError:
+                num_results = 10  # Default to 10 if conversion fails
+                
         # Run the search in a thread pool to prevent blocking
         loop = asyncio.get_event_loop()
         links = await loop.run_in_executor(


### PR DESCRIPTION
# Fix type conversion error for `num_results` parameter in `google_search` tool

## Description
### Problem
The following error occurred when executing the `google_search` tool:
```
2025-03-11 16:55:09.473 | ERROR    | app.agent.toolcall:execute_tool:162 - ⚠️ Tool 'google_search' encountered a problem: '<' not supported between instances of 'int' and 'str'
```

This error occurs when the `num_results` parameter is passed as a string. The `execute` method in the `GoogleSearch` class expects `num_results` to be an integer (int) type, but a string (str) was passed instead, causing a type error during comparison operations.

### Solution
Added logic to the `execute` method in the `GoogleSearch` class to convert the `num_results` parameter to an integer if it's a string. If the conversion fails, it defaults to 10.

### Changes
- Added type checking and conversion logic to the `execute` method in `app/tool/google_search.py`
- Set default value of 10 when a string cannot be converted to an integer

### Testing
- Verified normal operation when `num_results` is passed as an integer
- Verified normal operation when `num_results` is passed as a string containing a number
- Verified normal operation when `num_results` is passed as a non-numeric string, using the default value of 10

## Code Changes
```python
# Before
async def execute(self, query: str, num_results: int = 10) -> List[str]:
    # Run the search in a thread pool to prevent blocking
    loop = asyncio.get_event_loop()
    links = await loop.run_in_executor(
        None, lambda: list(search(query, num_results=num_results))
    )
    return links

# After
async def execute(self, query: str, num_results: int = 10) -> List[str]:
    # Ensure num_results is an integer
    if isinstance(num_results, str):
        try:
            num_results = int(num_results)
        except ValueError:
            num_results = 10  # Default to 10 if conversion fails
            
    # Run the search in a thread pool to prevent blocking
    loop = asyncio.get_event_loop()
    links = await loop.run_in_executor(
        None, lambda: list(search(query, num_results=num_results))
    )
    return links
```

## Related Issues
- Fixes #251 