### PR TITLE
fix infinite loop for simple query

### DIFF
--- a/app/prompt/manus.py
+++ b/app/prompt/manus.py
@@ -10,9 +10,9 @@ BrowserUseTool: Open, browse, and use web browsers.If you open a local HTML file
 
 GoogleSearch: Perform web information retrieval
 
-Based on user needs, proactively select the most appropriate tool or combination of tools. For complex tasks, you can break down the problem and use different tools step by step to solve it. After using each tool, clearly explain the execution results and suggest the next steps.
-
 Terminate: End the current interaction when the task is complete or when you need additional information from the user. Use this tool to signal that you've finished addressing the user's request or need clarification before proceeding further.
+
+Based on user needs, proactively select the most appropriate tool or combination of tools. For complex tasks, you can break down the problem and use different tools step by step to solve it. After using each tool, clearly explain the execution results and suggest the next steps.
 
 Always maintain a helpful, informative tone throughout the interaction. If you encounter any limitations or need more details, clearly communicate this to the user before terminating.
 """

--- a/app/prompt/manus.py
+++ b/app/prompt/manus.py
@@ -11,4 +11,8 @@ BrowserUseTool: Open, browse, and use web browsers.If you open a local HTML file
 GoogleSearch: Perform web information retrieval
 
 Based on user needs, proactively select the most appropriate tool or combination of tools. For complex tasks, you can break down the problem and use different tools step by step to solve it. After using each tool, clearly explain the execution results and suggest the next steps.
+
+Terminate: End the current interaction when the task is complete or when you need additional information from the user. Use this tool to signal that you've finished addressing the user's request or need clarification before proceeding further.
+
+Always maintain a helpful, informative tone throughout the interaction. If you encounter any limitations or need more details, clearly communicate this to the user before terminating.
 """


### PR DESCRIPTION
A very simple prompt edit to avoid the infinite loop of adding next_step_prompt

## Before fix
As the image shown, when user provides some very simple queries like "who are you", the agent would simply keep repeating itself. With a simple and sensible prompt edit, the agent could use the terminate function earlier and await additional user input instead of speaking to itself. 

![image](https://github.com/user-attachments/assets/a67f1fbd-c157-470b-a6b2-4179750026d7)

## After fix
![image](https://github.com/user-attachments/assets/da6812aa-7f1a-4986-8f8d-0a791664a9a5)
