### PR TITLE
Fix conflicting dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydantic~=2.10.4
-openai~=1.58.1
+openai>=1.61.0
 tenacity~=9.0.0
 pyyaml~=6.0.2
 loguru~=0.7.3


### PR DESCRIPTION
Fix issues:

ERROR: Cannot install -r requirements.txt (line 23), browser-use, browsergym-visualwebarena, browsergym-webarena and openai~=1.58.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested openai~=1.58.1
    libvisualwebarena 0.0.15 depends on openai>=1
    libwebarena 0.0.4 depends on openai>=1
    langchain-openai 0.3.1 depends on openai<2.0.0 and >=1.58.1
    litellm 1.63.6 depends on openai>=1.61.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts