### PR TITLE
将工具选择从 ToolChoice.REQUIRED 更新为 ToolChoice.AUTO，以优化规划代理和规划流程的工具调用逻辑。

### DIFF
--- a/app/agent/planning.py
+++ b/app/agent/planning.py
@@ -212,7 +212,7 @@ class PlanningAgent(ToolCallAgent):
             messages=messages,
             system_msgs=[Message.system_message(self.system_prompt)],
             tools=self.available_tools.to_params(),
-            tool_choice=ToolChoice.REQUIRED,
+            tool_choice=ToolChoice.AUTO,
         )
         assistant_msg = Message.from_tool_calls(
             content=response.content, tool_calls=response.tool_calls

--- a/app/flow/planning.py
+++ b/app/flow/planning.py
@@ -124,7 +124,7 @@ class PlanningFlow(BaseFlow):
             messages=[user_message],
             system_msgs=[system_message],
             tools=[self.planning_tool.to_param()],
-            tool_choice=ToolChoice.REQUIRED,
+            tool_choice=ToolChoice.AUTO,
         )
 
         # Process tool calls if present


### PR DESCRIPTION
REQUIRED导致模型在工作流中无法使用
