### PR TITLE
Allowing prompt on command line via Python argparse

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,13 @@
+import argparse
 import asyncio
 
 from app.agent.manus import Manus
 from app.logger import logger
 
 
-async def main():
+async def main(prompt: str = ""):
     agent = Manus()
     try:
-        prompt = input("Enter your prompt: ")
         if not prompt.strip():
             logger.warning("Empty prompt provided.")
             return
@@ -20,4 +20,11 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p","--prompt", type=str,help="task prompt for OpenManus")
+    args = parser.parse_args()
+    if args.prompt is not None:
+        user_prompt = args.prompt
+    else:
+        user_prompt = input("Enter your prompt: ")
+    asyncio.run(main(prompt=user_prompt))


### PR DESCRIPTION
**Features**
In some automated use cases for OpenManus, it is useful  to add the prompt from the command line: `python main.py -p "plan a trip to Paris"` or `python main.py --prompt "plan a trip to Paris"`

This PR allows it via use of Python argparse

**Feature Docs**

Doc for argparse: https://docs.python.org/3/library/argparse.html

**Influence**
 this will allow  more automated use of OpenManus as it can now be launched from command line with no required user interaction as with current interactive input()
**Result**

```
% python main.py -p "plan a trip to Paris"
INFO     [browser_use] BrowserUse logging setup complete with level info
INFO     [root] Anonymized telemetry enabled. See https://docs.browser-use.com/development/telemetry for more information.
2025-03-14 06:43:49.801 | WARNING  | __main__:main:15 - Processing your request...
2025-03-14 06:43:49.801 | INFO     | app.agent.base:run:137 - Executing step 1/20

```

