### PR TITLE
fix: if ToolChoice.AUTO and not tool_calls,should stop next act

### DIFF
--- a/app/agent/planning.py
+++ b/app/agent/planning.py
@@ -65,7 +65,7 @@ class PlanningAgent(ToolCallAgent):
 
         # After thinking, if we decided to execute a tool and it's not a planning tool or special tool,
         # associate it with the current step for tracking
-        if result and self.tool_calls:
+        if self.tool_calls:
             latest_tool_call = self.tool_calls[0]  # Get the most recent tool call
             if (
                 latest_tool_call.function.name != "planning"

--- a/app/agent/react.py
+++ b/app/agent/react.py
@@ -34,5 +34,6 @@ class ReActAgent(BaseAgent, ABC):
         """Execute a single step: think and act."""
         should_act = await self.think()
         if not should_act:
+            self.state = AgentState.FINISHED
             return "Thinking complete - no action needed"
         return await self.act()

--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -87,7 +87,7 @@ class ToolCallAgent(ReActAgent):
 
             # For 'auto' mode, continue with content if no commands but content exists
             if self.tool_choices == ToolChoice.AUTO and not self.tool_calls:
-                return bool(response.content)
+                return False
 
             return bool(self.tool_calls)
         except Exception as e:


### PR DESCRIPTION
**Features**
if ToolChoice.AUTO and not tool_calls,the subsequent action should be stopped. However, it`s not 
Simple Example：
before:
<img width="741" alt="0cfc5e56e1d201e999886417bb04809f" src="https://github.com/user-attachments/assets/80cb3da5-c956-4644-976f-5c409f75b173" />

after:
<img width="737" alt="69a7614929d2b14d453304814c6908c6" src="https://github.com/user-attachments/assets/34226e86-de12-41df-9eca-1f76d5649327" />
