### PR TITLE
fix(llm): improve message handling to support LLMs without content/tool_calls

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -84,14 +84,15 @@ class LLM:
         formatted_messages = []
 
         for message in messages:
+            if isinstance(message, Message):
+                message = message.to_dict()
             if isinstance(message, dict):
-                # If message is already a dict, ensure it has required fields
+                # If message is a dict, ensure it has required fields
                 if "role" not in message:
                     raise ValueError("Message dict must contain 'role' field")
-                formatted_messages.append(message)
-            elif isinstance(message, Message):
-                # If message is a Message object, convert it to dict
-                formatted_messages.append(message.to_dict())
+                if "content" in message or "tool_calls"  in message:
+                    formatted_messages.append(message)
+                # else: do not include the message
             else:
                 raise TypeError(f"Unsupported message type: {type(message)}")
 
@@ -99,10 +100,6 @@ class LLM:
         for msg in formatted_messages:
             if msg["role"] not in ROLE_VALUES:
                 raise ValueError(f"Invalid role: {msg['role']}")
-            if "content" not in msg and "tool_calls" not in msg:
-                raise ValueError(
-                    "Message must contain either 'content' or 'tool_calls'"
-                )
 
         return formatted_messages
 

--- a/app/llm.py
+++ b/app/llm.py
@@ -90,7 +90,7 @@ class LLM:
                 # If message is a dict, ensure it has required fields
                 if "role" not in message:
                     raise ValueError("Message dict must contain 'role' field")
-                if "content" in message or "tool_calls"  in message:
+                if "content" in message or "tool_calls" in message:
                     formatted_messages.append(message)
                 # else: do not include the message
             else:


### PR DESCRIPTION
**Features**  
- Improved message handling in the `LLM` class to gracefully handle messages without `content` or `tool_calls` fields.  
- Reordered message processing to check for `Message` objects first.  
- Changed validation approach to silently skip malformed messages instead of raising a `ValueError`.  
- Removed strict validation for missing `content` or `tool_calls` fields.  

This fixes:  
- Fixes #208
- Fixes #627
- Also Addresses #317 (the problem mentioned in the discussion of Issue)

**Feature Docs**  
N/A (Minor change to improve compatibility with Google's Gemini LLM.)  

**Influence**  
This change ensures compatibility with LLMs like Google's Gemini, which may return messages without `content` or `tool_calls` fields once in a while, they always seem useless anyway. It improves robustness and prevents crashes when working with such models.  

**Result**  
- Pre-commit checks passed after reformatting `app/llm.py` with `black`.  
- Tested with Google's Gemini and various message formats to confirm compatibility.  

**Other**  
This is a small but impactful change that unlocks support for Google's Gemini LLM while maintaining compatibility with existing models.  And solves multiple issues.

--- 

Let me know if you’d like further adjustments!