### PR TITLE
Fix temperature using default if 0

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -151,7 +151,7 @@ class LLM:
                 params["max_completion_tokens"] = self.max_tokens
             else:
                 params["max_tokens"] = self.max_tokens
-                params["temperature"] = temperature or self.temperature
+                params["temperature"] = temperature if temperature is not None else self.temperature
 
             if not stream:
                 # Non-streaming request
@@ -255,7 +255,7 @@ class LLM:
                 params["max_completion_tokens"] = self.max_tokens
             else:
                 params["max_tokens"] = self.max_tokens
-                params["temperature"] = temperature or self.temperature
+                params["temperature"] = temperature if temperature is not None else self.temperature
 
             response = await self.client.chat.completions.create(**params)
 

--- a/app/llm.py
+++ b/app/llm.py
@@ -151,7 +151,9 @@ class LLM:
                 params["max_completion_tokens"] = self.max_tokens
             else:
                 params["max_tokens"] = self.max_tokens
-                params["temperature"] = temperature if temperature is not None else self.temperature
+                params["temperature"] = (
+                    temperature if temperature is not None else self.temperature
+                )
 
             if not stream:
                 # Non-streaming request
@@ -255,7 +257,9 @@ class LLM:
                 params["max_completion_tokens"] = self.max_tokens
             else:
                 params["max_tokens"] = self.max_tokens
-                params["temperature"] = temperature if temperature is not None else self.temperature
+                params["temperature"] = (
+                    temperature if temperature is not None else self.temperature
+                )
 
             response = await self.client.chat.completions.create(**params)
 


### PR DESCRIPTION
**Features**
Correctly use the default parameter for `temperature`

**Influence**
`temperature` can be 0.0, however this results in the `or` case. Fix this by explicitly checking for `is not None`

**Result**
`temperature` only uses `self.temperature` if it's not passed
