### PR TITLE
Cache LLM and tool responses

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -1,0 +1,87 @@
+import hashlib
+import json
+import os
+import time
+from typing import Dict, List, Optional, Union, Any
+from diskcache import Cache
+
+from app.schema import Message
+from app.config import config
+
+
+class LLMCache:
+    """Cache for LLM responses to reduce API calls for identical requests."""
+
+    def __init__(self):
+        """
+        Initialize the LLM cache.
+        """
+        self.cache_dir = config.cache_config.cache_dir
+        self.cache_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), self.cache_dir)
+        os.makedirs(self.cache_dir, exist_ok=True)
+
+        self.ttl = config.cache_config.ttl
+        self.cache = Cache(self.cache_dir)
+
+    def generate_key(
+        self,
+        messages: List[Union[dict, Message]],
+        model: str,
+        temperature: float,
+        max_tokens: int,
+        tools: Optional[List[dict]] = None,
+    ) -> str:
+        """Generate a unique cache key based on request parameters."""
+        # Convert Message objects to dicts for consistent hashing
+        formatted_messages = []
+        for msg in messages:
+            if isinstance(msg, Message):
+                formatted_messages.append(msg.to_dict())
+            else:
+                formatted_messages.append(msg)
+
+        # Create a deterministic representation of the request
+        key_data = {
+            "messages": formatted_messages,
+            "model": model,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+
+        # Add tools to key if provided
+        if tools:
+            key_data["tools"] = tools
+
+        # Create a hash of the request data
+        key_str = json.dumps(key_data, sort_keys=True)
+        return hashlib.sha256(key_str.encode()).hexdigest()
+
+    def get(self, key: str) -> Optional[Any]:
+        """Retrieve a cached response if it exists and is valid."""
+        cached = self.cache.get(key)
+        if cached is None:
+            return None
+
+        data, timestamp = cached
+        if time.time() - timestamp > self.ttl:
+            # Expired cache entry
+            self.cache.delete(key)
+            return None
+
+        return data
+
+    def set(self, key: str, data: Any) -> None:
+        """Store a response in the cache with the current timestamp."""
+        self.cache.set(key, (data, time.time()))
+
+    def clear(self) -> None:
+        """Clear all cached responses."""
+        self.cache.clear()
+
+    def get_stats(self) -> Dict[str, int]:
+        """Return cache statistics."""
+        return {
+            "size": len(self.cache),
+            "hits": self.cache.stats(enable=True)["hits"],
+            "misses": self.cache.stats(enable=True)["misses"],
+        }

--- a/app/cache.py
+++ b/app/cache.py
@@ -27,8 +27,6 @@ class LLMCache:
         self,
         messages: List[Union[dict, Message]],
         model: str,
-        temperature: float,
-        max_tokens: int,
         tools: Optional[List[dict]] = None,
     ) -> str:
         """Generate a unique cache key based on request parameters."""
@@ -44,8 +42,6 @@ class LLMCache:
         key_data = {
             "messages": formatted_messages,
             "model": model,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
         }
 
         # Add tools to key if provided

--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,12 @@ class BrowserSettings(BaseModel):
         None, description="Proxy settings for the browser"
     )
 
+class CacheSettings(BaseModel):
+    enabled: bool = Field(False, description="Whether to enable caching")
+    ttl: int = Field(86400, description="Cache time-to-live in seconds")
+    cache_dir: str = Field(
+        "cache", description="Path to the cache directory"
+    )
 
 class AppConfig(BaseModel):
     llm: Dict[str, LLMSettings]
@@ -64,6 +70,9 @@ class AppConfig(BaseModel):
     )
     search_config: Optional[SearchSettings] = Field(
         None, description="Search configuration"
+    )
+    cache_config: Optional[CacheSettings] = Field(
+        None, description="Cache configuration"
     )
 
     class Config:
@@ -161,6 +170,9 @@ class Config:
         if search_config:
             search_settings = SearchSettings(**search_config)
 
+        cache_config = raw_config.get("cache", {})
+        cache_settings = CacheSettings(**cache_config)
+
         config_dict = {
             "llm": {
                 "default": default_settings,
@@ -171,6 +183,7 @@ class Config:
             },
             "browser_config": browser_settings,
             "search_config": search_settings,
+            "cache_config": cache_settings,
         }
 
         self._config = AppConfig(**config_dict)
@@ -186,6 +199,10 @@ class Config:
     @property
     def search_config(self) -> Optional[SearchSettings]:
         return self._config.search_config
+    
+    @property
+    def cache_config(self) -> Optional[CacheSettings]:
+        return self._config.cache_config
 
 
 config = Config()

--- a/app/llm.py
+++ b/app/llm.py
@@ -152,7 +152,7 @@ class LLM:
                 cache_key = self.cache.generate_key(messages, self.model)
                 cached_response = self.cache.get(cache_key)
                 if cached_response:
-                    logger.info("Using cached LLM response")
+                    logger.info("🧠💾 Using cached LLM response")
                     return cached_response
 
             params = {
@@ -179,6 +179,7 @@ class LLM:
 
                 # Save LLM response to cache if enabled
                 if self.cache_enabled:
+                    logger.info("💾🧠 Saving LLM response to cache")
                     cache_key = self.cache.generate_key(messages, self.model)
                     self.cache.set(cache_key, content)
 
@@ -201,6 +202,7 @@ class LLM:
 
             # Save LLM response to cache if enabled
             if self.cache_enabled:
+                logger.info("💾🧠 Saving LLM response to cache")
                 cache_key = self.cache.generate_key(messages, self.model)
                 self.cache.set(cache_key, full_response)
 
@@ -273,7 +275,7 @@ class LLM:
                 cache_key = self.cache.generate_key(messages, self.model, tools=tools)
                 cached_response = self.cache.get(cache_key)
                 if cached_response:
-                    logger.info("Using cached tool response")
+                    logger.info("🧠💾 Using cached tool response")
                     return cached_response
 
             # Set up the completion request
@@ -301,6 +303,7 @@ class LLM:
 
             # Save tool call response to cache if enabled
             if self.cache_enabled:
+                logger.info("💾🧠 Saving tool call response to cache")
                 cache_key = self.cache.generate_key(messages, self.model, tools=tools)
                 self.cache.set(cache_key, response.choices[0].message)
 

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -50,8 +50,8 @@ temperature = 0.0     # Controls randomness for vision model
 # Search engine for agent to use. Default is "Google", can be set to "Baidu" or "DuckDuckGo".
 #engine = "Google"
 
-[llm.default]
-# Existing config options...
-enabled = false
-ttl = 86400  # Cache time-to-live in seconds (24 hours)
-cache_dir = "cache"  # Path can be relative to project root or absolute
+# Optional configuration, Cache settings. Disabled by default.
+# [cache]
+# enabled = false
+# ttl = 86400  # Cache time-to-live in seconds (24 hour default)
+# cache_dir = "cache"  # Path to the cache. Supports relative to project root or absolute

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -49,3 +49,9 @@ temperature = 0.0     # Controls randomness for vision model
 # [search]
 # Search engine for agent to use. Default is "Google", can be set to "Baidu" or "DuckDuckGo".
 #engine = "Google"
+
+[llm.default]
+# Existing config options...
+enabled = false
+ttl = 86400  # Cache time-to-live in seconds (24 hours)
+cache_dir = "cache"  # Path can be relative to project root or absolute

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ aiofiles~=24.1.0
 pydantic_core~=2.27.2
 colorama~=0.4.6
 playwright~=1.49.1
+diskcache~=5.6.3


### PR DESCRIPTION
**Features**
Add caching for LLM and tool calls to increase speed and reduce API costs

- Add cache that stores prior messages, the model, and any tool calls for each request
- Perform saving/retrieving to and from cache in `llm.py` `ask` and `ask_tool`

**Feature Docs**
- Cache is saved to an SQLite DB, default path is `./cache/`
- Add cache configs to enable caching (disabled by default), set time-to-live, and set cache directory
- Uses `diskcache` library

**Influence**
Reduces API costs, especially during development when rerunning prompts
Increases speed, no more waiting for completion on repetitive tasks

**Result**
Using a cached response
<img width="784" alt="Screenshot 2025-03-14 at 9 19 07 PM" src="https://github.com/user-attachments/assets/3d5374a3-c4b0-4eb8-83c1-07e61d4706d8" />

Saving an unfamiliar response
<img width="778" alt="Screenshot 2025-03-14 at 9 19 29 PM" src="https://github.com/user-attachments/assets/d289dcd8-dbe0-4974-81f1-a17107494ac4" />
