### PR TITLE
fix browser_use parameter type

### DIFF
--- a/openmanus_server/openmanus_server.py
+++ b/openmanus_server/openmanus_server.py
@@ -44,12 +44,12 @@ terminate_tool = Terminate()
 @openmanus.tool()
 async def browser_use(
     action: str,
-    url: Optional[str] = None,
-    index: Optional[int] = None,
-    text: Optional[str] = None,
-    script: Optional[str] = None,
-    scroll_amount: Optional[int] = None,
-    tab_id: Optional[int] = None,
+    url: str = None,
+    index: int = None,
+    text: str = None,
+    script: str = None,
+    scroll_amount: int = None,
+    tab_id: int = None,
 ) -> str:
     """Execute various browser operations.
 


### PR DESCRIPTION
**Features**
# Initial LLM API call
        response = await self.openai_client.chat.completions.create(
            model=self.config["llm"]["model"],
            messages=messages,
            tools=available_tools,
            tool_choice="auto",
        )

**Result**
修复因为browser_use参数问题导致的self.openai_client.chat.completions.create报错
"code":"InvalidParameter","message":"One or more parameters specified in the request are not valid

