### PR TITLE
feat: Use [browser.proxy] of config.toml to be the proxy of googlesearch

### DIFF
--- a/app/tool/google_search.py
+++ b/app/tool/google_search.py
@@ -44,7 +44,7 @@ The tool returns a list of URLs that match the search query.
         if cls._proxy_initialized is True:
             logger.info("Proxy settings already initialized. Using cached proxy settings.")
             return cls._proxy_str
-        
+
         cls._proxy_initialized = True
         if config.browser_config and config.browser_config.proxy:
             logger.info("Proxy settings found in config")
@@ -56,6 +56,7 @@ The tool returns a list of URLs that match the search query.
                 cls._proxy_str = cls._proxy_str.replace("://", f"://{proxy_auth}")
         else:
             logger.info("No proxy settings found in config")
+            cls._proxy_str = None
         
         return cls._proxy_str
 

--- a/app/tool/google_search.py
+++ b/app/tool/google_search.py
@@ -4,7 +4,8 @@ from typing import List
 from googlesearch import search
 
 from app.tool.base import BaseTool
-
+from app.config import config
+from loguru import logger
 
 class GoogleSearch(BaseTool):
     name: str = "google_search"
@@ -28,6 +29,36 @@ The tool returns a list of URLs that match the search query.
         "required": ["query"],
     }
 
+    # Class variable for caching proxy settings
+    _proxy_str = None
+    _proxy_initialized = False
+    
+    @classmethod
+    def _get_proxy_settings(cls) -> str:
+        """
+        Get proxy settings from config. This method is called only once and the result is cached.
+        
+        Returns:
+            dict: Proxy settings dictionary or None if no proxy is configured
+        """        
+        if cls._proxy_initialized is True:
+            logger.info("Proxy settings already initialized. Using cached proxy settings.")
+            return cls._proxy_str
+        
+        cls._proxy_initialized = True
+        if config.browser_config and config.browser_config.proxy:
+            logger.info("Proxy settings found in config")
+            proxy_config = config.browser_config.proxy
+            # Directly access attributes instead of using get method
+            cls._proxy_str = str(proxy_config.server)
+            if proxy_config.username and proxy_config.password:
+                proxy_auth = f"{proxy_config.username}:{proxy_config.password}@"
+                cls._proxy_str = cls._proxy_str.replace("://", f"://{proxy_auth}")
+        else:
+            logger.info("No proxy settings found in config")
+        
+        return cls._proxy_str
+
     async def execute(self, query: str, num_results: int = 10) -> List[str]:
         """
         Execute a Google search and return a list of URLs.
@@ -41,8 +72,22 @@ The tool returns a list of URLs that match the search query.
         """
         # Run the search in a thread pool to prevent blocking
         loop = asyncio.get_event_loop()
+        
+        # Determine search parameters based on proxy settings
+        search_kwargs = {
+            "num_results": num_results,
+        }
+        
+        # Get proxy settings
+        proxy_str = self._get_proxy_settings()
+        logger.info(f"Using proxy from config.")    
+            
+        if proxy_str:
+            search_kwargs["proxy"] = proxy_str
+            
         links = await loop.run_in_executor(
-            None, lambda: list(search(query, num_results=num_results))
+            None, 
+            lambda: list(search(query, **search_kwargs))
         )
 
         return links


### PR DESCRIPTION
**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Feature 1
Support [browser.proxy] to be used in GoogleSearch

**Feature Docs**
When searching via GoogleSearch, there is no proxy for it from configuration file config.toml. So we could reuse the value of [browser.proxy] to GoogleSearch if proxy is set in [browser.proxy].

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->
Allow user to set proxy for GoogleSearch.

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->
Message 'Proxy settings found in config' would be thrown out if proxy is used in GoogleSearch.
<img width="941" alt="image" src="https://github.com/user-attachments/assets/761fbce7-7567-43d6-a787-2e6bd3d79aa8" />


**Other**
<!-- Additional notes about this PR. -->
