### PR TITLE
fix(dependencies): resolve pydantic_core version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ baidusearch~=1.0.3
 duckduckgo_search~=7.5.1
 
 aiofiles~=24.1.0
-pydantic_core~=2.32.0
+pydantic_core~=2.27.2
 colorama~=0.4.6
 playwright~=1.50.0


### PR DESCRIPTION
## Features  
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->  

- Fixed dependency conflict with `pydantic_core`  
- Updated `requirements.txt` to ensure compatibility with `pydantic 2.10.6`  

## Feature Docs  
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->  
- [Pydantic Dependency Documentation](https://docs.pydantic.dev/latest/)  

## Influence  
<!-- Explain the impact of these changes for reviewer focus. -->  
- Ensures `pip install -r requirements.txt` works without conflicts  
- Prevents dependency resolution issues related to `pydantic_core`  
- No breaking changes expected  

## Result  
<!-- Include screenshots or logs of unit tests or running results. -->  
- Tested successfully with Python 3.12  
- Logs show successful installation of dependencies  

## Other  
<!-- Additional notes about this PR. -->  
- This fix addresses errors encountered when installing dependencies using `pip install -r requirements.txt`  
- The issue was caused by `pydantic_core~=2.32.0` conflicting with `pydantic 2.10.6`, which requires `pydantic-core==2.27.2`  
- Updated `pydantic_core` to `2.27.2` to match requirements  

<img width="1036" alt="Screenshot 2025-03-16 at 7 17 01 pm" src="https://github.com/user-attachments/assets/3d574a14-7b11-466c-956a-b642b6a4401b" />
