### PR TITLE
Fix pydantic_core version to 2.27.2 to resolve dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ baidusearch~=1.0.3
 duckduckgo_search~=7.5.1
 
 aiofiles~=24.1.0
-pydantic_core~=2.32.0
+pydantic_core~=2.27.2
 colorama~=0.4.6
 playwright~=1.50.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "browser-use~=0.1.40",
         "googlesearch-python~=1.3.0",
         "aiofiles~=24.1.0",
-        "pydantic_core>=2.27.2,<2.33.0",
+        "pydantic_core>=2.27.2,<2.28.0",
         "colorama~=0.4.6",
     ],
     classifiers=[


### PR DESCRIPTION
# Fix pydantic_core version to 2.27.2 to resolve dependency conflict

**Features**
- Fixed the dependency conflict between pydantic 2.10.6 and pydantic_core
- Updated version constraint in requirements.txt from ~=2.32.0 to ~=2.27.2
- Ensured consistency in setup.py with compatible version range

**Feature Docs**
This is a bug fix that resolves dependency resolution errors during installation, so no feature documentation is needed.

**Influence**
This change impacts the installation process for all users. Without this fix, users encounter a "ResolutionImpossible" error during installation because:
- pydantic 2.10.6 specifically requires pydantic-core==2.27.2
- The previous constraint of pydantic_core~=2.32.0 creates an unsatisfiable dependency

The fix ensures that the versions are compatible, allowing successful installation without dependency conflicts.

**Result**
Before:
```
ERROR: Cannot install -r requirements.txt (line 1) and pydantic_core~=2.32.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested pydantic_core~=2.32.0
    pydantic 2.10.6 depends on pydantic-core==2.27.2
    
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

After:
```
Successfully installed pydantic-2.10.6 pydantic-core-2.27.2 [and other packages]
```

**Other**
This PR aligns with dependency management best practices by ensuring that all package requirements are compatible. The change is minimal and only affects the installation process, not runtime behavior.
