### PR TITLE
Updated environment-corrupt-check.yaml to use newer versions of github actions

### DIFF
--- a/.github/workflows/environment-corrupt-check.yaml
+++ b/.github/workflows/environment-corrupt-check.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip


### PR DESCRIPTION
Updated environment-corrupt-check.yaml to use newer versions of github actions