### PR TITLE
Fix LLM initialization error with custom LLMSettings

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -47,8 +47,8 @@ class LLM:
         self, config_name: str = "default", llm_config: Optional[LLMSettings] = None
     ):
         if not hasattr(self, "client"):  # Only initialize if not already initialized
-            llm_config = llm_config or config.llm
-            llm_config = llm_config.get(config_name, llm_config["default"])
+            if not llm_config:
+                llm_config = config.llm.get(config_name, config.llm["default"])
             self.model = llm_config.model
             self.max_tokens = llm_config.max_tokens
             self.temperature = llm_config.temperature


### PR DESCRIPTION
**Features**
- Fix LLM initialization error when passing custom LLMSettings object. The bug was caused by trying to use dictionary operations (get()) on a Pydantic model. 

**Feature Docs**

**Influence**
- Affects LLM initialization when using custom LLMSettings objects
- No impact on existing code using config names
- Critical for users who need to pass custom LLM configurations programmatically

**Result**
Before fix:
```
custom_settings = LLMSettings(...)
llm = LLM(llm_config=custom_settings)
# AttributeError: 'LLMSettings' object has no attribute 'get'
```
After fix:
```
custom_settings = LLMSettings(...)
llm = LLM(llm_config=custom_settings)
# Works correctly
```

**Other**

