### PR TITLE
Update windows install guide in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ pip install -r requirements.txt
 
 ### Method 2: Using uv (Recommended)
 
+#### Linux/macOS
+
 1. Install uv (A fast Python package installer and resolver):
 
 ```bash
@@ -71,8 +73,6 @@ cd OpenManus
 ```bash
 uv venv --python 3.12
 source .venv/bin/activate  # On Unix/macOS
-# Or on Windows:
-# .venv\Scripts\activate
 ```
 
 4. Install dependencies:
@@ -80,6 +80,50 @@ source .venv/bin/activate  # On Unix/macOS
 ```bash
 uv pip install -r requirements.txt
 ```
+
+#### Windows
+
+1. Install uv (A fast Python package installer and resolver):
+
+   **Method 1: Using PowerShell**
+
+   Open PowerShell (preferably as administrator) and run:
+
+   ```powershell
+   iwr -useb https://astral.sh/uv/install.ps1 | iex
+   ```
+
+   **Method 2: Using pip**
+
+   If you already have Python and pip installed, you can run:
+
+   ```
+   pip install uv
+   ```
+
+   **Method 3: Download from GitHub**
+
+   Visit the [uv releases page](https://github.com/astral-sh/uv/releases), download the latest Windows installer, and run it.
+
+2. Clone the repository:
+
+   ```
+   git clone https://github.com/mannaandpoem/OpenManus.git
+   cd OpenManus
+   ```
+
+3. Create a new virtual environment and activate it:
+
+   ```
+   uv venv --python 3.12
+   .venv\Scripts\activate
+   ```
+
+4. Install dependencies:
+
+   ```
+   uv pip install -r requirements.txt
+   ```
 
 ## Configuration
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -53,6 +53,8 @@ pip install -r requirements.txt
 
 ### 方法2：uvを使用（推奨）
 
+#### Linux/macOS
+
 1. uv（高速なPythonパッケージインストーラーと管理機能）をインストールします：
 
 ```bash
@@ -71,8 +73,6 @@ cd OpenManus
 ```bash
 uv venv --python 3.12
 source .venv/bin/activate  # Unix/macOSの場合
-# Windowsの場合：
-# .venv\Scripts\activate
 ```
 
 4. 依存関係をインストールします：
@@ -80,6 +80,50 @@ source .venv/bin/activate  # Unix/macOSの場合
 ```bash
 uv pip install -r requirements.txt
 ```
+
+#### Windows
+
+1. uv（高速なPythonパッケージインストーラーと管理機能）をインストールします：
+
+   **方法1：PowerShellを使用**
+
+   PowerShell（できれば管理者権限で）を開き、次を実行します：
+
+   ```powershell
+   iwr -useb https://astral.sh/uv/install.ps1 | iex
+   ```
+
+   **方法2：pipを使用**
+
+   すでにPythonとpipがインストールされている場合は、次を実行できます：
+
+   ```
+   pip install uv
+   ```
+
+   **方法3：GitHubからダウンロード**
+
+   [uvリリースページ](https://github.com/astral-sh/uv/releases)にアクセスし、最新のWindowsインストーラーをダウンロードして実行します。
+
+2. リポジトリをクローンします：
+
+   ```
+   git clone https://github.com/mannaandpoem/OpenManus.git
+   cd OpenManus
+   ```
+
+3. 新しい仮想環境を作成してアクティベートします：
+
+   ```
+   uv venv --python 3.12
+   .venv\Scripts\activate
+   ```
+
+4. 依存関係をインストールします：
+
+   ```
+   uv pip install -r requirements.txt
+   ```
 
 ## 設定
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -53,6 +53,8 @@ pip install -r requirements.txt
 
 ### 방법 2: uv 사용 (권장)
 
+#### Linux/macOS
+
 1. uv를 설치합니다. (빠른 Python 패키지 설치 및 종속성 관리 도구):
 
 ```bash
@@ -71,8 +73,6 @@ cd OpenManus
 ```bash
 uv venv --python 3.12
 source .venv/bin/activate  # Unix/macOS의 경우
-# Windows의 경우:
-# .venv\Scripts\activate
 ```
 
 4. 종속성을 설치합니다:
@@ -80,6 +80,50 @@ source .venv/bin/activate  # Unix/macOS의 경우
 ```bash
 uv pip install -r requirements.txt
 ```
+
+#### Windows
+
+1. uv를 설치합니다. (빠른 Python 패키지 설치 및 종속성 관리 도구):
+
+   **방법 1: PowerShell 사용**
+
+   PowerShell을 열고(가능하면 관리자 권한으로) 다음을 실행합니다:
+
+   ```powershell
+   iwr -useb https://astral.sh/uv/install.ps1 | iex
+   ```
+
+   **방법 2: pip 사용**
+
+   이미 Python과 pip가 설치되어 있다면 다음을 실행할 수 있습니다:
+
+   ```
+   pip install uv
+   ```
+
+   **방법 3: GitHub에서 다운로드**
+
+   [uv 릴리스 페이지](https://github.com/astral-sh/uv/releases)를 방문하여 최신 Windows 설치 프로그램을 다운로드하고 실행합니다.
+
+2. 저장소를 클론합니다:
+
+   ```
+   git clone https://github.com/mannaandpoem/OpenManus.git
+   cd OpenManus
+   ```
+
+3. 새로운 가상 환경을 생성하고 활성화합니다:
+
+   ```
+   uv venv --python 3.12
+   .venv\Scripts\activate
+   ```
+
+4. 종속성을 설치합니다:
+
+   ```
+   uv pip install -r requirements.txt
+   ```
 
 ## 설정 방법
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -54,6 +54,8 @@ pip install -r requirements.txt
 
 ### 方式二：使用 uv（推荐）
 
+#### Linux/macOS 系统
+
 1. 安装 uv（一个快速的 Python 包管理器）：
 
 ```bash
@@ -72,8 +74,6 @@ cd OpenManus
 ```bash
 uv venv --python 3.12
 source .venv/bin/activate  # Unix/macOS 系统
-# Windows 系统使用：
-# .venv\Scripts\activate
 ```
 
 4. 安装依赖：
@@ -81,6 +81,50 @@ source .venv/bin/activate  # Unix/macOS 系统
 ```bash
 uv pip install -r requirements.txt
 ```
+
+#### Windows 系统
+
+1. 安装 uv（一个快速的 Python 包管理器）：
+
+   **方法 1：使用 PowerShell**
+
+   打开 PowerShell（建议以管理员身份运行）并执行：
+
+   ```powershell
+   iwr -useb https://astral.sh/uv/install.ps1 | iex
+   ```
+
+   **方法 2：使用 pip**
+
+   如果已安装 Python 和 pip，可以直接执行：
+
+   ```
+   pip install uv
+   ```
+
+   **方法 3：从 GitHub 下载**
+
+   访问 [uv 发布页面](https://github.com/astral-sh/uv/releases)，下载最新的 Windows 安装包并运行。
+
+2. 克隆仓库：
+
+   ```
+   git clone https://github.com/mannaandpoem/OpenManus.git
+   cd OpenManus
+   ```
+
+3. 创建并激活虚拟环境：
+
+   ```
+   uv venv --python 3.12
+   .venv\Scripts\activate
+   ```
+
+4. 安装依赖：
+
+   ```
+   uv pip install -r requirements.txt
+   ```
 
 ## 配置说明
 


### PR DESCRIPTION
## Features
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Added Windows installation steps for uv in all language versions of README files
- Structured installation guide with separate sections for Linux/macOS and Windows
- Provided three methods for installing uv on Windows systems

## Feature Docs
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

The changes follow the installation guide format from the Chinese version (README_zh.md) and apply consistent formatting across all language versions.

## Influence
<!-- Explain the impact of these changes for reviewer focus. -->

These changes improve the documentation for Windows users by providing clear, step-by-step installation instructions in all supported languages (English, Korean, and Japanese). This ensures a consistent user experience regardless of the user's preferred language and operating system.

## Result
<!-- Include screenshots or logs of unit tests or running results. -->

Successfully updated the following files:
- README.md (English)
- README_ko.md (Korean)
- README_ja.md (Japanese)

Each file now includes detailed Windows installation steps with three installation methods for uv:
1. Using PowerShell
2. Using pip
3. Downloading from GitHub

## Other
<!-- Additional notes about this PR. -->

The changes maintain consistency across all language versions while respecting language-specific formatting and terminology. The Windows installation section follows the same structure as the existing Linux/macOS section, making the documentation more comprehensive and user-friendly.
