### PR TITLE
I added configurable function_description_limit for tool API calls for Openai Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ base_url = "https://api.openai.com/v1"
 api_key = "sk-..."  # Replace with your actual API key
 max_tokens = 4096
 temperature = 0.0
+function_description_limit = 1024 #Openai Expected maximum length in Prompt when using Openai model
 
 # Optional configuration for specific LLM models
 [llm.vision]


### PR DESCRIPTION
**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

I Introduced a configurable function_description_limit parameter in config.toml to dynamically set the maximum allowed length for tool function descriptions.
- Updated the LLM initialization to read and store the function_description_limit from configuration.
- Modified the ask_tool method to use helper functions (get_api_ready_description and prepare_tool_for_api) that enforce the dynamic description limit based on the current model's constraints, ensuring compatibility with both models requiring 1024-character limits (e.g., GPT-4o) and those that support longer inputs (e.g., Claude).

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

- It Prevents API errors caused by tool descriptions exceeding model-specific limits.
- it Provides developers with the flexibility to define more detailed tool descriptions for models that accept longer inputs, while ensuring compliance with stricter models.
- It Enhances robustness and clarity in how tools are prepared for API calls, thereby reducing unexpected runtime errors.


**Result**
<!-- Include screenshots or logs of unit tests or running results. -->
The Unit tests confirm that for models with a 1024-character limit, descriptions are appropriately truncated with a warning log.
For models like Claude that allow longer descriptions (e.g., 4096 characters), the full description is preserved as configured.
- Sample log output:
```
Tool 'example_tool' description length (1634) exceeds 1024 characters. Consider providing a concise 'short_description'.

```
**Other**
<!-- Additional notes about this PR. -->
