### PR TITLE
update api_type field description to include Ollama

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,7 +25,7 @@ class LLMSettings(BaseModel):
         description="Maximum input tokens to use across all requests (None for unlimited)",
     )
     temperature: float = Field(1.0, description="Sampling temperature")
-    api_type: str = Field(..., description="AzureOpenai or Openai")
+    api_type: str = Field(..., description="Azure, Openai, or Ollama")
     api_version: str = Field(..., description="Azure Openai version if AzureOpenai")
 
 


### PR DESCRIPTION
Clarify the description of the api_type field in LLMSettings to accurately reflect all supported types including Azure, OpenAI, and Ollama. This makes the documentation consistent with the example configuration.

**Features**
- Update LLMSettings.api_type description in config.py to include 'ollama' as a valid option alongside 'azure' and 'openai'

**Influence**
This change improves documentation accuracy by aligning the field description with the actual supported options in config.example.toml. While functionality is unchanged, proper documentation ensures users know that 'ollama' is a valid configuration option.

**Result**
The updated description more accurately represents the current supported options and aligns with the configuration examples provided in config.example.toml.

