### PR TITLE
Center align logo, language links, and badges in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,27 @@
-<p align="center">
-  <img src="assets/logo.jpg" width="200"/>
-</p>
+<div align="center">
+  <p>
+    <img src="assets/logo.jpg" width="200" alt="OpenManus Logo"/>
+  </p>
+  <p>
+    <strong>
+      English | <a href="README_zh.md">中文</a> | <a href="README_ko.md">한국어</a> | <a href="README_ja.md">日本語</a>
+    </strong>
+  </p>
 
-English | [中文](README_zh.md) | [한국어](README_ko.md) | [日本語](README_ja.md)
-
-[![GitHub stars](https://img.shields.io/github/stars/mannaandpoem/OpenManus?style=social)](https://github.com/mannaandpoem/OpenManus/stargazers)
-&ensp;
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) &ensp;
-[![Discord Follow](https://dcbadge.vercel.app/api/server/DYn29wFk9z?style=flat)](https://discord.gg/DYn29wFk9z)
+  <p>
+    <a href="https://github.com/mannaandpoem/OpenManus/stargazers">
+      <img src="https://img.shields.io/github/stars/mannaandpoem/OpenManus?style=social" alt="GitHub stars"/>
+    </a>
+    &ensp;
+    <a href="https://opensource.org/licenses/MIT">
+      <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"/>
+    </a>
+    &ensp;
+    <a href="https://discord.gg/DYn29wFk9z">
+      <img src="https://dcbadge.vercel.app/api/server/DYn29wFk9z?style=flat" alt="Discord Follow"/>
+    </a>
+  </p>
+</div>
 
 # 👋 OpenManus
 


### PR DESCRIPTION
This pull request improves the visual structure of the README.md by centering the key elements at the top, making the layout cleaner. 

#### Before (Previous Layout):
 - The logo, language links, and badges were left-aligned.
 - This caused an unbalanced appearance, especially on larger screens.
 
![Previous layout ](https://github.com/user-attachments/assets/70eee881-0608-47ee-b57e-1cef5fc6bda3)

### After (New Centered Layout):
 - The logo is now centered.
 - The language links (English | 中文 | 한국어 | 日本語) are centered for better readability.
 - The badges (GitHub Stars, License, Discord Follow) are now neatly centered.
 
![New Layout](https://github.com/user-attachments/assets/7002dd16-2b16-4b23-8a35-7cd1623a36b5)

Why This Change is Necessary?
 - Improves visual balance in the README.
 - Enhances readability.
 - Consistent alignment across all elements.