### PR TITLE
Adding support for key based auth to Azure AI Foundry

### DIFF
--- a/app/aiFoundry.py
+++ b/app/aiFoundry.py
@@ -1,0 +1,58 @@
+import sys
+from typing import Dict, List, Literal, Optional
+
+from azure.ai.inference import ChatCompletionsClient
+from azure.core.credentials import AzureKeyCredential
+from azure.identity import DefaultAzureCredential
+
+class AzureFoundryClient:
+    def __init__(self, endpoint, apiKey, useEntra=False):
+        try:
+            if useEntra:
+                self.client = ChatCompletionsClient(
+                    endpoint=endpoint,
+                    credential=DefaultAzureCredential(),
+                    credential_scopes=["https://cognitiveservices.azure.com/.default"],
+                )
+            else:
+                self.client = ChatCompletionsClient (
+                    endpoint=endpoint,
+                    credential=AzureKeyCredential(apiKey)
+                )
+            self.chat = Chat(self.client)
+        except Exception as e:
+            print(f"Error initializing Azure Foundry client: {e}")
+            sys.exit(1)
+
+class Chat:
+    def __init__(self, client):
+        self.completions = ChatCompletions(client)
+
+class ChatCompletions:
+    def __init__(self, client):
+        self.client = client
+
+    async def create(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+        stream: Optional[bool] = True,
+        tools: Optional[List[dict]] = None,
+        tool_choice: Literal["none", "auto", "required"] = "auto",
+        **kwargs,           
+    ):
+        return self.client.complete(
+            messages=messages,
+            max_tokens=max_tokens,
+            model=model,
+            stream=stream,
+            temperature=temperature,
+            tools=tools,
+            tool_choice=tool_choice,
+            **kwargs
+        )
+        
+
+            

--- a/app/llm.py
+++ b/app/llm.py
@@ -18,6 +18,7 @@ from tenacity import (
     wait_random_exponential,
 )
 
+from app.aiFoundry import AzureFoundryClient
 from app.bedrock import BedrockClient
 from app.config import LLMSettings, config
 from app.exceptions import TokenLimitExceeded
@@ -225,6 +226,12 @@ class LLM:
                     base_url=self.base_url,
                     api_key=self.api_key,
                     api_version=self.api_version,
+                )
+            elif self.api_type == "azureAIFoundry":
+                self.client = AzureFoundryClient(
+                    endpoint=self.base_url,
+                    apiKey=self.api_key,
+                    useEntra=True
                 )
             elif self.api_type == "aws":
                 self.client = BedrockClient()

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -47,6 +47,15 @@ temperature = 0.0                           # Controls randomness for vision mod
 # max_tokens = 4096
 # temperature = 0.0
 
+# [llm] #AZUREAIFOUNDRY:
+# api_type= 'azureAIFoundry'
+# model = "<model_name>"
+# base_url = "https://<yourservice>.services.ai.azure.com/models"
+# api_key = "only required when using key based auth. Otherwise just run az auth before running"
+# max_tokens = 8192
+# temperature = 0.0
+# api_version="2024-05-01-preview" #"2024-08-01-preview"
+
 # Optional configuration for specific browser configuration
 # [browser]
 # Whether to run browser in headless mode (default: false)

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,5 @@ httpx>=0.27.0
 tomli>=2.0.0
 
 boto3~=1.37.16
+azure-ai-inference
+azure-identity


### PR DESCRIPTION
**Features**
Adding support to use Azure AI Foundry (https://azure.microsoft.com/en-us/products/ai-foundry). This open up the code to use any open source model available on Azure.

Supports both api_key and Entra Id authentication.

**Influence**
Consumers can now use Azure AI Foundry based models include O3, DeepSeek-R1 and many other fine tuned versions available on Azure AI Foundry

**Result**
Please let me know what results make sense
![image](https://github.com/user-attachments/assets/fb592e73-a504-49e4-b238-0714d10bf513)


