### PR TITLE
Fix ImportError & Enhance <think> tag handling in message processing

### DIFF
--- a/app/schema.py
+++ b/app/schema.py
@@ -178,11 +178,11 @@ class Message(BaseModel):
             for call in tool_calls
         ]
 
-        # 处理内容中的思考部分
+        # Processing the reflective portion within the content.
         if isinstance(content, str):
             processed_content = cls.remove_think_content(content)
         else:
-            # 如果是列表，处理每个字符串
+            # If it is a list, process each string.
             processed_content = [cls.remove_think_content(c) for c in content]
 
         return cls(

--- a/run_flow.py
+++ b/run_flow.py
@@ -2,8 +2,7 @@ import asyncio
 import time
 
 from app.agent.manus import Manus
-from app.flow.base import FlowType
-from app.flow.flow_factory import FlowFactory
+from app.flow.flow_factory import FlowFactory, FlowType
 from app.logger import logger
 
 


### PR DESCRIPTION
**Features**
- After running `python run_flow.py`, the following error occurred:  **ImportError: cannot import name 'FlowType' from 'app.flow.base'** 
The issue was resolved by changing the import path from app.flow.base to app.flow.flow_factory.
- Filter out the thought process before storing message history & Enhance think tag handling in message processing (#475)
  - Add robust handling for think tag content removal
  - Handle edge case where only </think> tag exists without <think>
  - Improve message creation methods to filter thinking content
  - Add comprehensive error handling for null/empty content