### PR TITLE
Fix up typo for enabling type hint

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -18,7 +18,7 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from app.bedrock import BedrockClient
+from app.bedrock import BedrockClient, OpenAIResponse
 from app.config import LLMSettings, config
 from app.exceptions import TokenLimitExceeded
 from app.logger import logger  # Assuming a logger is set up in your app
@@ -735,7 +735,7 @@ class LLM:
                     temperature if temperature is not None else self.temperature
                 )
 
-            response: ChatCompletion = await self.client.chat.completions.create(
+            response: OpenAIResponse = await self.client.chat.completions.create(
                 **params, stream=False
             )
 


### PR DESCRIPTION
`ChatResponse` does not exist, so replace it with `OpenAIResponse` class for type hint

**Features**

- There was some typo (referencing non-existing class), so I replace it with `OpenAIResponse` class.
- Now, we could use type hint for that variable properly
