### PR TITLE
Fix manus agent's next step prompt accidentally overwritten by browser agent

### DIFF
--- a/app/agent/browser.py
+++ b/app/agent/browser.py
@@ -111,14 +111,14 @@ class BrowserAgent(ToolCallAgent):
                 )
                 self.memory.add_message(image_message)
 
-        # Replace placeholders with actual browser state info
-        self.next_step_prompt = NEXT_STEP_PROMPT.format(
-            url_placeholder=url_info,
-            tabs_placeholder=tabs_info,
-            content_above_placeholder=content_above_info,
-            content_below_placeholder=content_below_info,
-            results_placeholder=results_info,
-        )
+            # Replace placeholders with actual browser state info
+            self.next_step_prompt = NEXT_STEP_PROMPT.format(
+                url_placeholder=url_info,
+                tabs_placeholder=tabs_info,
+                content_above_placeholder=content_above_info,
+                content_below_placeholder=content_below_info,
+                results_placeholder=results_info,
+            )
 
         # Call parent implementation
         result = await super().think()

--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -43,16 +43,16 @@ class Manus(BrowserAgent):
         original_prompt = self.next_step_prompt
 
         # Only check recent messages (last 3) for browser activity
-        # recent_messages = self.memory.messages[-3:] if self.memory.messages else []
-        # browser_in_use = any(
-        #     "browser_use" in msg.content.lower()
-        #     for msg in recent_messages
-        #     if hasattr(msg, "content") and isinstance(msg.content, str)
-        # )
+        recent_messages = self.memory.messages[-3:] if self.memory.messages else []
+        browser_in_use = any(
+            "browser_use" in msg.content.lower()
+            for msg in recent_messages
+            if hasattr(msg, "content") and isinstance(msg.content, str)
+        )
 
-        # if browser_in_use:
-        #     # Override with browser-specific prompt temporarily to get browser context
-        #     self.next_step_prompt = BROWSER_NEXT_STEP_PROMPT
+        if browser_in_use:
+            # Override with browser-specific prompt temporarily to get browser context
+            self.next_step_prompt = BROWSER_NEXT_STEP_PROMPT
 
         # Call parent's think method
         result = await super().think()

--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -43,16 +43,16 @@ class Manus(BrowserAgent):
         original_prompt = self.next_step_prompt
 
         # Only check recent messages (last 3) for browser activity
-        recent_messages = self.memory.messages[-3:] if self.memory.messages else []
-        browser_in_use = any(
-            "browser_use" in msg.content.lower()
-            for msg in recent_messages
-            if hasattr(msg, "content") and isinstance(msg.content, str)
-        )
+        # recent_messages = self.memory.messages[-3:] if self.memory.messages else []
+        # browser_in_use = any(
+        #     "browser_use" in msg.content.lower()
+        #     for msg in recent_messages
+        #     if hasattr(msg, "content") and isinstance(msg.content, str)
+        # )
 
-        if browser_in_use:
-            # Override with browser-specific prompt temporarily to get browser context
-            self.next_step_prompt = BROWSER_NEXT_STEP_PROMPT
+        # if browser_in_use:
+        #     # Override with browser-specific prompt temporarily to get browser context
+        #     self.next_step_prompt = BROWSER_NEXT_STEP_PROMPT
 
         # Call parent's think method
         result = await super().think()


### PR DESCRIPTION
**Features**
In the Manus.think () method: the code checks whether the recent message contains "browser_use" If so, set self.next_step_prompt to BROWSER_NEXT_STEP_PROMPT and then call await super ().think () (which is BrowserAgent.think ()) 
<img width="642" alt="image" src="https://github.com/user-attachments/assets/c95d6d92-a90d-4753-ac84-cffb79d3c97b" />
In the BrowserAgent.think () method: No matter what the current value of self.next_step_prompt is, it will be reformatted. This means that whether or not the line self.next_step_prompt = BROWSER_NEXT_STEP_PROMPT is executed in Manus.think (), BrowserAgent.think () will overwrite the value and eventually reset it. So, if browser_in_use this judgment is indeed redundant, because its effect will be completely overridden by the BrowserAgent.think () method
<img width="580" alt="image" src="https://github.com/user-attachments/assets/ea4cac78-aaf3-47fc-b380-e5aefa71558a" />

The modified browser agent will only override next_step_prompt if the browser is available, not in any case
<img width="749" alt="image" src="https://github.com/user-attachments/assets/8ca23efc-a243-4df2-a459-12a619fd0221" />
