### PR TITLE
完整的计划应当被去除 不应该被单个step看见 否则后面base.py的run函数就会自动把plan里面的step做完

### DIFF
--- a/app/flow/planning.py
+++ b/app/flow/planning.py
@@ -264,9 +264,6 @@ class PlanningFlow(BaseFlow):
 
         # Create a prompt for the agent to execute the current step
         step_prompt = f"""
-        CURRENT PLAN STATUS:
-        {plan_status}
-
         YOUR CURRENT TASK:
         You are now working on step {self.current_step_index}: "{step_text}"
 


### PR DESCRIPTION
**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Feature 1
- Feature 2

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

**Other**
<!-- Additional notes about this PR. -->
    async def run(self, request: Optional[str] = None) -> str:
        """Execute the agent's main loop asynchronously.

        Args:
            request: Optional initial user request to process.

        Returns:
            A string summarizing the execution results.

        Raises:
            RuntimeError: If the agent is not in IDLE state at start.
        """
        if self.state != AgentState.IDLE:
            raise RuntimeError(f"Cannot run agent from state: {self.state}")

        if request:
            self.update_memory("user", request)

        results: List[str] = []
        async with self.state_context(AgentState.RUNNING):
            while (
                self.current_step < self.max_steps and self.state != AgentState.FINISHED
            ):
                print(f"base run start, state:{self.state}")
                self.current_step += 1
                logger.info(f"Executing step {self.current_step}/{self.max_steps}")
                step_result = await self.step()

                # Check for stuck state
                if self.is_stuck():
                    self.handle_stuck_state()

                results.append(f"Step {self.current_step}: {step_result}")

                print(f"base run end, state:{self.state}")

            if self.current_step >= self.max_steps:
                self.current_step = 0
                self.state = AgentState.IDLE
                results.append(f"Terminated: Reached max steps ({self.max_steps})")
        await SANDBOX_CLIENT.cleanup()
        return "\n".join(results) if results else "No steps executed"
        这里的step在think的时候 由于大模型拥有完整的plan 会自行把后面的step做完
