### PR TITLE
Fix type error  where the arg is  double-encoded JSON

### DIFF
--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -176,6 +176,9 @@ class ToolCallAgent(ReActAgent):
             # Parse arguments
             args = json.loads(command.function.arguments or "{}")
 
+            # If args is still a string, parse it again to handle double-encoded JSON
+            args = json.loads(args) if isinstance(args, str) else args
+
             # Execute the tool
             logger.info(f"🔧 Activating tool: '{name}'...")
             result = await self.available_tools.execute(name=name, tool_input=args)


### PR DESCRIPTION

**Features**  
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->  

- Fixed an issue where `args` might still be a JSON string after the initial parsing.  
- Added an additional `json.loads(args)` step to correctly handle double-encoded JSON.  

**Feature Docs**  
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->  
N/A  

**Influence**  
<!-- Explain the impact of these changes for reviewer focus. -->  
- Some models, such as `Qwen/Qwen2.5-7B-Instruct`, return `command.function.arguments` as a JSON string.  
- This fix ensures that `args` is always correctly parsed into a dictionary before passing it to the tool.  
- Prevents errors caused by incorrectly formatted arguments.  

**Result**  
<!-- Include screenshots or logs of unit tests or running results. -->  
Unit tests passed successfully, and the tool now correctly processes JSON arguments.  

**Other**  
<!-- Additional notes about this PR. -->  
N/A  