### PR TITLE
fix the nested json format issue

### DIFF
--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -175,7 +175,8 @@ class ToolCallAgent(ReActAgent):
         try:
             # Parse arguments
             args = json.loads(command.function.arguments or "{}")
-
+            while isinstance(args, str):
+                args = json.loads(args)
             # Execute the tool
             logger.info(f"🔧 Activating tool: '{name}'...")
             result = await self.available_tools.execute(name=name, tool_input=args)


### PR DESCRIPTION
**Features**
Some models(Qwen2.5-72B-instruct in my case) will output nested JSON format when calling the tool, resulting in the result of a single `json.loads(args)` still being a string, which in turn causes an error. This bug has been fixed. 
