### PR TITLE
The problem may be solved before the plan is executed completely. Therefore, add judgment between the execution steps. If the problem has been solved, the remaining steps will not be executed.

### DIFF
--- a/app/tool/early_terminate.py
+++ b/app/tool/early_terminate.py
@@ -1,0 +1,24 @@
+from app.tool.base import BaseTool
+
+
+_EARLY_TERMINATE_DESCRIPTION = """A tool determined whether a problem has been solved earlier than plan completed."""
+
+
+class EarlyTerminateTool(BaseTool):
+    name: str = "early_terminate"
+    description: str = _EARLY_TERMINATE_DESCRIPTION
+    parameters: dict = {
+        "type": "object",
+        "properties": {
+            "is_end_early": {
+                "type": "string",
+                "description": "Whether problem ends earlier than plan completed.",
+                "enum": ["yes", "no"],
+            }
+        },
+        "required": ["is_end_early"],
+    }
+
+    async def execute(self, status: str) -> str:
+        """Finish the current execution"""
+        pass


### PR DESCRIPTION
executed completely. Therefore, add judgment between the execution steps. If the problem has been solved, the remaining steps will not be executed.

**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Feature 1 user's request may be solved before plan executed compeletly, remianing steps not necessary to be executed.
- Feature 2 get results faster for simple problem.

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

**Other**
<!-- Additional notes about this PR. -->
