### PR TITLE
fix：Update toolcall.py Simplify Code

### DIFF
--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -188,14 +188,6 @@ class ToolCallAgent(ReActAgent):
                 # Store the base64_image for later use in tool_message
                 self._current_base64_image = result.base64_image
 
-                # Format result for display
-                observation = (
-                    f"Observed output of cmd `{name}` executed:\n{str(result)}"
-                    if result
-                    else f"Cmd `{name}` completed with no output"
-                )
-                return observation
-
             # Format result for display (standard case)
             observation = (
                 f"Observed output of cmd `{name}` executed:\n{str(result)}"


### PR DESCRIPTION
The code in the toolcall.py seems to duplicate

**Result**
before：
# Check if result is a ToolResult with base64_image
            if hasattr(result, "base64_image") and result.base64_image:
                # Store the base64_image for later use in tool_message
                self._current_base64_image = result.base64_image

                # Format result for display
                observation = (
                    f"Observed output of cmd `{name}` executed:\n{str(result)}"
                    if result
                    else f"Cmd `{name}` completed with no output"
                )
                return observation

            # Format result for display (standard case)
            observation = (
                f"Observed output of cmd `{name}` executed:\n{str(result)}"
                if result
                else f"Cmd `{name}` completed with no output"
            )
            return observation
after：
# Check if result is a ToolResult with base64_image
            if hasattr(result, "base64_image") and result.base64_image:
                # Store the base64_image for later use in tool_message
                self._current_base64_image = result.base64_image

            # Format result for display (standard case)
            observation = (
                f"Observed output of cmd `{name}` executed:\n{str(result)}"
                if result
                else f"Cmd `{name}` completed with no output"
            )
            return observation
