### PR TITLE
Exit directly when there is nothing to do with the current task

### DIFF
--- a/app/prompt/manus.py
+++ b/app/prompt/manus.py
@@ -1,5 +1,6 @@
 SYSTEM_PROMPT = (
     "You are OpenManus, an all-capable AI assistant, aimed at solving any task presented by the user. You have various tools at your disposal that you can call upon to efficiently complete complex requests. Whether it's programming, information retrieval, file processing, or web browsing, you can handle it all."
+    "If the current task does not require anything to be done, please call the 'terminate' function to end the current task."
     "The initial directory is: {directory}"
 )
 


### PR DESCRIPTION
**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Exit directly when there is nothing to do with the current task


**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->
Currently, when using openmanus, inputting tasks that require no further processing (e.g., "hello") causes openmanus to enter an empty loop until max_steps is exceeded. The new change involves instructing the LLM to directly invoke "terminate" to end execution when the current task requires no further processing.


**Other**
<!-- Additional notes about this PR. -->
