### PR TITLE
feat: update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM python:3.12-slim
+FROM python:3.11
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PLAYWRIGHT_BROWSERS_PATH=/app/ms-playwright
+
+RUN apt-get update && apt-get install -y
+RUN pip install playwright
+RUN playwright install --with-deps chromium
 
 WORKDIR /app/OpenManus
 
@@ -6,8 +14,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends git curl \
     && rm -rf /var/lib/apt/lists/* \
     && (command -v uv >/dev/null 2>&1 || pip install --no-cache-dir uv)
 
-COPY . .
+COPY requirements.txt .
 
 RUN uv pip install --system -r requirements.txt
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y xvfb
+RUN apt-get install -qqy x11-apps
+
+RUN apt-get install -y libnss3 \
+    libxss1 \
+    libasound2 \
+    fonts-noto-color-emoji xauth
+
+COPY . .
+
+ENTRYPOINT ["/bin/sh", "-c", "/usr/bin/xvfb-run -a $@", ""]
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ COPY . .
 
 ENTRYPOINT ["/bin/sh", "-c", "/usr/bin/xvfb-run -a $@", ""]
 
-CMD ["bash"]
+CMD ["python3", "/app/OpenManus/main.py"]


### PR DESCRIPTION
**Features**
- An updated Dockerfile that supports headless browsing and a fully working environment

**Feature Docs**
To Build the docker image: 
` docker build -t manus .`

To run it: 
`docker run -v ${PWD}:/app/OpenManus/workspace -it manus`

The -v flag makes it so the workspace files can be retrieved after the task is complete. It is not required for use if its not needed in your use case. Also, by default it runs main.py, but this can be overridden using docker cli flags too (for running bash or the other scripts).

**Influence**
Dockerfile is the only file updated. It just adds support for browsing and fixes other issues using manus in a container. It also lets OpenManus run easily on windows.

**Result**
![image](https://github.com/user-attachments/assets/e9b68030-43f1-4404-9fba-909551e934a4)


**Other**
Nothing else, unless there are questions.
