### PR TITLE
feat(mcp-server): Add support for environment variables (env) configuration

### DIFF
--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -81,6 +81,7 @@ class Manus(ToolCallAgent):
                             server_id,
                             use_stdio=True,
                             stdio_args=server_config.args,
+                            stdio_env=server_config.env
                         )
                         logger.info(
                             f"Connected to MCP server {server_id} using command {server_config.command}"
@@ -94,11 +95,12 @@ class Manus(ToolCallAgent):
         server_id: str = "",
         use_stdio: bool = False,
         stdio_args: List[str] = None,
+        stdio_env: dict[str, str] | None = None
     ) -> None:
         """Connect to an MCP server and add its tools."""
         if use_stdio:
             await self.mcp_clients.connect_stdio(
-                server_url, stdio_args or [], server_id
+                server_url, stdio_args or [], stdio_env, server_id
             )
             self.connected_servers[server_id or server_url] = server_url
         else:

--- a/app/config.py
+++ b/app/config.py
@@ -108,6 +108,7 @@ class MCPServerConfig(BaseModel):
     args: List[str] = Field(
         default_factory=list, description="Arguments for stdio command"
     )
+    env: dict[str, str] = Field(None, description="The environment to use when spawning the process")
 
 
 class MCPSettings(BaseModel):
@@ -140,6 +141,7 @@ class MCPSettings(BaseModel):
                         url=server_config.get("url"),
                         command=server_config.get("command"),
                         args=server_config.get("args", []),
+                        env=server_config.get("env", {}),
                     )
                 return servers
         except Exception as e:

--- a/app/tool/mcp.py
+++ b/app/tool/mcp.py
@@ -69,7 +69,7 @@ class MCPClients(ToolCollection):
         await self._initialize_and_list_tools(server_id)
 
     async def connect_stdio(
-        self, command: str, args: List[str], server_id: str = ""
+        self, command: str, args: List[str], env: dict[str, str] | None, server_id: str = ""
     ) -> None:
         """Connect to an MCP server using stdio transport."""
         if not command:
@@ -84,7 +84,7 @@ class MCPClients(ToolCollection):
         exit_stack = AsyncExitStack()
         self.exit_stacks[server_id] = exit_stack
 
-        server_params = StdioServerParameters(command=command, args=args)
+        server_params = StdioServerParameters(command=command, args=args, env=env)
         stdio_transport = await exit_stack.enter_async_context(
             stdio_client(server_params)
         )

--- a/config/mcp.example.json
+++ b/config/mcp.example.json
@@ -1,8 +1,19 @@
 {
-    "mcpServers": {
-      "server1": {
-        "type": "sse",
-        "url": "http://localhost:8000/sse"
+  "mcpServers": {
+    "server1": {
+      "type": "sse",
+      "url": "http://localhost:8000/sse"
+    },
+    "server2": {
+      "type": "stdio",
+      "command": "python",
+      "args": [
+        "-m",
+        "<path>"
+      ],
+      "env": {
+        "key": "xxx"
       }
     }
+  }
 }


### PR DESCRIPTION
**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

PR Description
Summary
This PR introduces support for configuring the MCP Server via environment variables (env parameters). Users can now dynamically set runtime configurations (e.g., ports, logging levels, API keys) through environment variables, enhancing deployment flexibility and alignment with DevOps practices.

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

**Other**
<!-- Additional notes about this PR. -->
