### PR TITLE
Simplify return statement in count_image by removing redundant comments

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -88,16 +88,9 @@ class TokenCounter:
                 width, height = image_item["dimensions"]
                 return self._calculate_high_detail_tokens(width, height)
 
-        # Default values when dimensions aren't available or detail level is unknown
-        if detail == "high":
-            # Default to a 1024x1024 image calculation for high detail
-            return self._calculate_high_detail_tokens(1024, 1024)  # 765 tokens
-        elif detail == "medium":
-            # Default to a medium-sized image for medium detail
-            return 1024  # This matches the original default
-        else:
-            # For unknown detail levels, use medium as default
-            return 1024
+        return (
+            self._calculate_high_detail_tokens(1024, 1024) if detail == "high" else 1024
+        )
 
     def _calculate_high_detail_tokens(self, width: int, height: int) -> int:
         """Calculate tokens for high detail images based on dimensions"""


### PR DESCRIPTION
This PR makes a small cleanup in the `count_image` method:

- Removes unnecessary comments
- Simplifies the return statement for better readability
- No change in logic or behavior

Pre-commit checks have been run successfully to ensure code quality.
