### PR TITLE
Fix MCPAgent AttributeError due to outdated `session` references after MCPClients refactor

### DIFF
--- a/app/agent/mcp.py
+++ b/app/agent/mcp.py
@@ -90,11 +90,12 @@ class MCPAgent(ToolCallAgent):
         Returns:
             A tuple of (added_tools, removed_tools)
         """
-        if not self.mcp_clients.session:
+        session = next(iter(self.mcp_clients.sessions.values()), None)
+        if not session:
             return [], []
 
         # Get current tool schemas directly from the server
-        response = await self.mcp_clients.session.list_tools()
+        response = await session.list_tools()
         current_tools = {tool.name: tool.inputSchema for tool in response.tools}
 
         # Determine added, removed, and changed tools

--- a/app/agent/mcp.py
+++ b/app/agent/mcp.py
@@ -135,7 +135,7 @@ class MCPAgent(ToolCallAgent):
     async def think(self) -> bool:
         """Process current state and decide next action."""
         # Check MCP session and tools availability
-        if not self.mcp_clients.session or not self.mcp_clients.tool_map:
+        if not self.mcp_clients.sessions or not self.mcp_clients.tool_map:
             logger.info("MCP service is no longer available, ending interaction")
             self.state = AgentState.FINISHED
             return False
@@ -172,7 +172,7 @@ class MCPAgent(ToolCallAgent):
 
     async def cleanup(self) -> None:
         """Clean up MCP connection when done."""
-        if self.mcp_clients.session:
+        if self.mcp_clients.sessions:
             await self.mcp_clients.disconnect()
             logger.info("MCP connection closed")
 


### PR DESCRIPTION
**Features**

- Fix MCPAgent to correctly reference `self.mcp_clients.sessions` instead of the obsolete `self.mcp_clients.session`.
- Update `_refresh_tools`, `think()`, and `cleanup()` methods to properly support multiple MCP sessions.
- Prevents runtime AttributeError when running `run_mcp.py`.

**Feature Docs**

- No documentation updates required — internal bug fix only.

**Influence**

- Fixes a blocking runtime bug introduced by MCPClients multi-session support (commit 7326cca4504fdaf5249ca3c2d36e39d09d83a6a7).
- Ensures MCPAgent can properly initialize, think, and clean up across sessions.
- Unblocks users trying to run OpenManus MCP agents in `stdio` mode or others.

**Result**

- Manual run after fix: agent initializes, connects via `stdio`, prompts the user, and executes successfully without crashes.
- Verified that tools are properly refreshed and agent cleanup occurs without errors.

**Other**

- This PR closes #[1099](https://github.com/mannaandpoem/OpenManus/issues/1099).
- Confirmed this was introduced in commit `7326cca4504fdaf5249ca3c2d36e39d09d83a6a7`.
- Future follow-up work: optional support for selecting among multiple sessions explicitly, if desired.

